### PR TITLE
Fix LLVM crash issue

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -35,7 +35,6 @@ def runCompileCommand(platform, project, jobName, boolean debug=false)
     // avoid bug causing long build times of certain files.
     String buildType = 'Release' // debug ? 'Debug' : 'RelWithDebInfo'
     String parallelJobs = "export HIPCC_COMPILE_FLAGS_APPEND='-O3 -Wno-format-nonliteral -parallel-jobs=4'"
-    String buildThreads = '16' // if hipcc is used may be multiplied by parallel-jobs
 
     // comment
 
@@ -63,7 +62,7 @@ def runCompileCommand(platform, project, jobName, boolean debug=false)
             pushd build
 
             export PATH=/opt/rocm/bin:\$PATH
-            cmake -DCMAKE_BUILD_TYPE=${buildType} -DCMAKE_CXX_COMPILER=${compiler} -DTensile_CPU_THREADS=${buildThreads} -DTensile_ROOT=\$(pwd)/../Tensile ../HostLibraryTests
+            cmake -DCMAKE_BUILD_TYPE=${buildType} -DCMAKE_CXX_COMPILER=${compiler} -DTensile_ROOT=\$(pwd)/../Tensile ../HostLibraryTests
             NPROC_BUILD=16
             if [ `nproc` -lt 16 ]
             then

--- a/.jenkins/extended.groovy
+++ b/.jenkins/extended.groovy
@@ -45,7 +45,7 @@ def runCI =
 
     boolean formatCheck = false
 
-    prj.timeout.test = 720
+    prj.timeout.test = 600
     prj.defaults.ccache = false
 
     def commonGroovy

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -1279,8 +1279,8 @@ def TensileCreateLibrary():
     theMasterLibrary = list(masterLibraries.values())[0]
 
   if args.EmbedLibrary is not None:
-      embedFileName = os.path.join(outputPath, "library/{}.cpp".format(args.EmbedLibrary))
-      with EmbeddedData.EmbeddedDataFile(embedFileName) as embedFile:
+      embedFileNameTemp = os.path.join(outputPath, "library/{}.temp".format(args.EmbedLibrary))
+      with EmbeddedData.EmbeddedDataFile(embedFileNameTemp) as embedFile:
 
           ext = ".yaml" if globalParameters["LibraryFormat"] == "yaml" else ".dat"
           embedFile.embed_file(theMasterLibrary.cpp_base_class, masterFile + ext, nullTerminated=True,
@@ -1289,6 +1289,8 @@ def TensileCreateLibrary():
           for co in Utils.tqdm(codeObjectFiles):
               embedFile.embed_file("SolutionAdapter", co, nullTerminated=False,
                                    key=args.EmbedLibraryKey)
+      embedFileNameCpp = os.path.join(outputPath, "library/{}.cpp".format(args.EmbedLibrary))
+      os.rename(embedFileNameTemp, embedFileNameCpp)
 
   if args.BuildClient:
     print1("# Building Tensile Client")

--- a/Tensile/cmake/TensileConfig.cmake
+++ b/Tensile/cmake/TensileConfig.cmake
@@ -286,7 +286,7 @@ function(TensileCreateLibraryFiles
         COMMAND ${CommandLine}
       )
 
-      set("${Tensile_VAR_PREFIX}_ALL_FILES" ${Tensile_MANIFEST_CONTENTS} PARENT_SCOPE)
+      set("${Tensile_VAR_PREFIX}_ALL_FILES" ${Tensile_EMBED_LIBRARY_SOURCE};${Tensile_MANIFEST_CONTENTS} PARENT_SCOPE)
 
       # Create a chained library build target.
       # We've declared the manifest contents as output of the custom
@@ -295,7 +295,7 @@ function(TensileCreateLibraryFiles
       # command to be invoked at build time, not cmake time.
       TensileCreateCopyTarget(
       "${Tensile_VAR_PREFIX}_LIBRARY_TARGET"
-      "${Tensile_MANIFEST_CONTENTS}"
+      "${Tensile_EMBED_LIBRARY_SOURCE};${Tensile_MANIFEST_CONTENTS}"
       "${Tensile_OUTPUT_PATH}/library"
     )
 


### PR DESCRIPTION
LLVM crash was caused by make trying to run the build step on embed files before they were finished generating. Embed files can be very large CPP files and may take more than a couple seconds to write to disk. The make target has a dependency on the cpp file, but it parallel builds it seems to activate anytime it notices the file is present, not necessarily when python finishes writing it and closes the handle.

To work around the issue, the embed file is now written to a .temp file which is renamed to .cpp when it is finished and closed. This prevents make from starting the build step early.

There should be a way to accomplish this with a custom cmake target+dependency instead, but my experiments with setting that up caused other build issues like missing build files.

This PR also reverts the recent changes to reduce build threads and increase test timeout to see if this change is enough to fix the build issues for CI.