### PR TITLE
Remove WGM related kern args if they are not needed

### DIFF
--- a/Tensile/Components/Signature.py
+++ b/Tensile/Components/Signature.py
@@ -293,9 +293,10 @@ class SignatureDefault(Signature):
                 kStr += self.addArgument("skExtraIters",        '4', offset,"by_value", "u32"); offset += 4
                 # kStr += self.addArgument("dpTilesPerWG",        '4', offset,"by_value", "u32"); offset += 4
 
-        kStr += self.addArgument(                   "NumFullBlocks",     '4', offset,      "by_value",        "u32"); offset += 4
-        kStr += self.addArgument(                   "WgmRemainder1",     '4', offset,      "by_value",        "u32"); offset += 4
-        kStr += self.addArgument(        "MagicNumberWgmRemainder1",     '4', offset,      "by_value",        "u32"); offset += 4
+        if abs(kernel["WorkGroupMapping"]) > 1:
+            kStr += self.addArgument(                   "NumFullBlocks",     '4', offset,      "by_value",        "u32"); offset += 4
+            kStr += self.addArgument(                   "WgmRemainder1",     '4', offset,      "by_value",        "u32"); offset += 4
+            kStr += self.addArgument(        "MagicNumberWgmRemainder1",     '4', offset,      "by_value",        "u32"); offset += 4
 
         # for in-device stochastic rounding, iwe need to pass Seed 
         # TODO: if kernel["ProblemType"]["StochasticRounding"] == 1:    # in-device 

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -1939,9 +1939,12 @@ class KernelWriterAssembly(KernelWriter):
     # Mostly impacts flat kernels and GSU edge since these need SGPR
     # for conditionals
     self.lastPostLoopSgpr = self.sgprPool.size()
-    self.defineSgpr("NumFullBlocks", 1) # Magic number to use for div by (NumWorkGroups1 % WGM)
-    self.defineSgpr("WgmRemainder1", 1) # Magic number to use for div by (NumWorkGroups1 % WGM)
-    self.defineSgpr("MagicNumberWgmRemainder1", 1) # Magic number to use for div by (NumWorkGroups1 % WGM)
+    self.numSgprWGM = 0
+    if abs(kernel["WorkGroupMapping"]) > 1:
+      self.numSgprWGM = 3
+      self.defineSgpr("NumFullBlocks", 1) # Magic number to use for div by (NumWorkGroups1 % WGM)
+      self.defineSgpr("WgmRemainder1", 1) # Magic number to use for div by (NumWorkGroups1 % WGM)
+      self.defineSgpr("MagicNumberWgmRemainder1", 1) # Magic number to use for div by (NumWorkGroups1 % WGM)
 
     # SR only for F8 type
     if kernel["ProblemType"]["DataType"].is8bitFloat():
@@ -1972,7 +1975,7 @@ class KernelWriterAssembly(KernelWriter):
       2 + \
       pkArgumentToLoad + \
       skArgumentToLoad + \
-      3 + \
+      self.numSgprWGM + \
       self.numSgprOffsetD + self.numSgprOffsetC + self.numSgprOffsetA + self.numSgprOffsetB
 
     # SR only for F8 type

--- a/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -675,9 +675,12 @@ namespace Tensile
                 magicNumberWgmRemainder1 = smallMagicNumber(wgmRemainder1);
             }
 
-            rv.args.append<uint32_t>("numFullBlocks", numFullBlocks);
-            rv.args.append<uint32_t>("wgmRemainder1", wgmRemainder1);
-            rv.args.append<uint32_t>("magicNumberWgmRemainder1", magicNumberWgmRemainder1);
+            if(std::abs(sizeMapping.workGroupMapping) > 1)
+            {
+                rv.args.append<uint32_t>("numFullBlocks", numFullBlocks);
+                rv.args.append<uint32_t>("wgmRemainder1", wgmRemainder1);
+                rv.args.append<uint32_t>("magicNumberWgmRemainder1", magicNumberWgmRemainder1);
+            }
         }
 
         if(problemType.stochasticRounding)


### PR DESCRIPTION
WGM mapping arguments are not used if WGM is -1, 0, 1. This change updates the signature so that these arguments don't need to be passed when not used.

Built rocblas using this change and all gemm-related tests passed locally on gfx90a.