### PR TITLE
Predicate for arithmetic intensity

### DIFF
--- a/HostLibraryTests/CMakeLists.txt
+++ b/HostLibraryTests/CMakeLists.txt
@@ -131,6 +131,7 @@ set(test_sources ${test_sources}
     DataTypes_test.cpp
     EmbeddedData_test.cpp
     KernelArguments_test.cpp
+    Predicates_test.cpp
     ProjectedPerformance_test.cpp
     DecisionTree_test.cpp
     TensorDescriptor_test.cpp

--- a/HostLibraryTests/Predicates_test.cpp
+++ b/HostLibraryTests/Predicates_test.cpp
@@ -31,11 +31,15 @@
 TEST(Predicates, ArithmeticIntensity)
 {
     using namespace Tensile;
-    
-    ContractionProblem a = ContractionProblem::GEMM(false, true, 1000, 1500, 500, 2000, 2000, 2000, 3.0, false, 1);     // 88.4
-    ContractionProblem b = ContractionProblem::GEMM(false, true, 500, 1000, 1000, 2000, 2000, 2000, 0.0, false, 5);     // 125
-    ContractionProblem c = ContractionProblem::GEMM(false, true, 2000, 100, 2000, 2000, 2000, 2000, 1.0, false, 10);    // 43.5
-    ContractionProblem d = ContractionProblem::GEMM(false, true, 2000, 2000, 450, 2000, 2000, 2000, 2.0, false, 1);     // 92.04
+
+    ContractionProblem a = ContractionProblem::GEMM(
+        false, true, 1000, 1500, 500, 2000, 2000, 2000, 3.0, false, 1); // 88.4
+    ContractionProblem b = ContractionProblem::GEMM(
+        false, true, 500, 1000, 1000, 2000, 2000, 2000, 0.0, false, 5); // 125
+    ContractionProblem c = ContractionProblem::GEMM(
+        false, true, 2000, 100, 2000, 2000, 2000, 2000, 1.0, false, 10); // 43.5
+    ContractionProblem d = ContractionProblem::GEMM(
+        false, true, 2000, 2000, 450, 2000, 2000, 2000, 2.0, false, 1); // 92.04
 
     auto pg1 = std::make_shared<Predicates::Contraction::AIGreaterThanEqual>(100);
     auto pg2 = std::make_shared<Predicates::Contraction::AIGreaterThanEqual>(75);

--- a/HostLibraryTests/Predicates_test.cpp
+++ b/HostLibraryTests/Predicates_test.cpp
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <Tensile/ContractionProblemPredicates.hpp>
+
+TEST(Predicates, ArithmeticIntensity)
+{
+    using namespace Tensile;
+    
+    ContractionProblem a = ContractionProblem::GEMM(false, true, 1000, 1500, 500, 2000, 2000, 2000, 3.0, false, 1);     // 88.4
+    ContractionProblem b = ContractionProblem::GEMM(false, true, 500, 1000, 1000, 2000, 2000, 2000, 0.0, false, 5);     // 125
+    ContractionProblem c = ContractionProblem::GEMM(false, true, 2000, 100, 2000, 2000, 2000, 2000, 1.0, false, 10);    // 43.5
+    ContractionProblem d = ContractionProblem::GEMM(false, true, 2000, 2000, 450, 2000, 2000, 2000, 2.0, false, 1);     // 92.04
+
+    auto pg1 = std::make_shared<Predicates::Contraction::AIGreaterThanEqual>(100);
+    auto pg2 = std::make_shared<Predicates::Contraction::AIGreaterThanEqual>(75);
+    auto pl1 = std::make_shared<Predicates::Contraction::AILessThanEqual>(100);
+    auto pl2 = std::make_shared<Predicates::Contraction::AILessThanEqual>(75);
+
+    EXPECT_EQ(false, (*pg1)(a));
+    EXPECT_EQ(true, (*pg2)(a));
+    EXPECT_EQ(true, (*pl1)(a));
+    EXPECT_EQ(false, (*pl2)(a));
+
+    EXPECT_EQ(true, (*pg1)(b));
+    EXPECT_EQ(true, (*pg2)(b));
+    EXPECT_EQ(false, (*pl1)(b));
+    EXPECT_EQ(false, (*pl2)(b));
+
+    EXPECT_EQ(false, (*pg1)(c));
+    EXPECT_EQ(false, (*pg2)(c));
+    EXPECT_EQ(true, (*pl1)(c));
+    EXPECT_EQ(true, (*pl2)(c));
+
+    EXPECT_EQ(false, (*pg1)(d));
+    EXPECT_EQ(true, (*pg2)(d));
+    EXPECT_EQ(true, (*pl1)(d));
+    EXPECT_EQ(false, (*pl2)(d));
+}

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -843,6 +843,10 @@ validParameters = {
     "AssertSizeLessThan":    -1,
     "AssertSizeMultiple":    -1,
 
+    # Assertions that require arithmetic intensity to be specified value.
+    "AssertAIGreaterThanEqual": -1,
+    "AssertAILessThanEqual":    -1,
+
     #Assert values for alpha and beta
     "AssertBetaValue":       [False, 1, -1],
     "AssertAlphaValue":      [False, 1, -1],
@@ -1491,6 +1495,8 @@ defaultBenchmarkCommonParameters = [
     {"AssertSizeGreaterThan":     [ {} ] },
     {"AssertSizeMultiple":        [ {} ] },
     {"AssertSizeLessThan":        [ {} ] },
+    {"AssertAIGreaterThanEqual":  [ -1 ] },
+    {"AssertAILessThanEqual":     [ -1 ] },
     {"AssertAlphaValue":          [ False ]},
     {"AssertBetaValue":           [ False ]},
     {"AssertCEqualsD":            [ False ]},

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -844,6 +844,8 @@ validParameters = {
     "AssertSizeMultiple":    -1,
 
     # Assertions that require arithmetic intensity to be specified value.
+    # Arithmetic intensity measures the ratio of computation to memory bandwidth required for a problem.
+    # These predicates can be used to adjust solution selection compute-bound or memory-bound problems.
     "AssertAIGreaterThanEqual": -1,
     "AssertAILessThanEqual":    -1,
 

--- a/Tensile/Contractions.py
+++ b/Tensile/Contractions.py
@@ -317,7 +317,13 @@ class ProblemPredicate(Properties.Predicate):
         if key == "AssertSizeMultiple":
             return extractDimPredicate(cls, key, value, "SizeMultiple")
 
-        #Alpha and beta value assertions
+        # Arithmetic intensity assertions
+        if key == "AssertAIGreaterThanEqual":
+            return cls("AIGreaterThanEqual", value=value) if value > 0 else None
+        if key == "AssertAILessThanEqual":
+            return cls("AILessThanEqual", value=value) if value > 0 else None
+
+        # Alpha and beta value assertions
         if key == "AssertAlphaValue":
             return cls("AlphaValue", value=str(value)) if value != False else None
         if key == "AssertBetaValue":

--- a/Tensile/Source/lib/include/Tensile/ContractionProblem.hpp
+++ b/Tensile/Source/lib/include/Tensile/ContractionProblem.hpp
@@ -508,6 +508,11 @@ namespace Tensile
             return m_cEqualsD;
         }
 
+        double arithmeticIntensity() const
+        {
+            return m_arithmeticIntensity;
+        }
+
         void setAlphaType(DataType type)
         {
             m_alphaType = type;
@@ -861,6 +866,8 @@ namespace Tensile
         KernelLanguage    m_kernelLanguage          = KernelLanguage::Any;
         PerformanceMetric m_performanceMetric       = PerformanceMetric::DeviceEfficiency;
 
+        double m_arithmeticIntensity;
+
         DataType m_alphaType = DataType::None; // if not assigned, will follow d-type
         DataType m_betaType  = DataType::None; // for bwd-compatible
 
@@ -897,6 +904,7 @@ namespace Tensile
 
         void normalize();
         void consistencyCheck() const;
+        void calcArithmeticIntensity();
 
         void getIndexNames(std::string& aNames,
                            std::string& bNames,

--- a/Tensile/Source/lib/include/Tensile/ContractionProblemPredicates.hpp
+++ b/Tensile/Source/lib/include/Tensile/ContractionProblemPredicates.hpp
@@ -920,7 +920,8 @@ namespace Tensile
                 }
             };
 
-            struct AIGreaterThanEqual : public Predicate_CRTP<AIGreaterThanEqual, ContractionProblem>
+            struct AIGreaterThanEqual
+                : public Predicate_CRTP<AIGreaterThanEqual, ContractionProblem>
             {
                 enum
                 {

--- a/Tensile/Source/lib/include/Tensile/ContractionProblemPredicates.hpp
+++ b/Tensile/Source/lib/include/Tensile/ContractionProblemPredicates.hpp
@@ -920,6 +920,82 @@ namespace Tensile
                 }
             };
 
+            struct AIGreaterThanEqual : public Predicate_CRTP<AIGreaterThanEqual, ContractionProblem>
+            {
+                enum
+                {
+                    HasIndex = false,
+                    HasValue = true
+                };
+
+                double value;
+
+                AIGreaterThanEqual() = default;
+                AIGreaterThanEqual(double value)
+                    : value(value)
+                {
+                }
+
+                static std::string Type()
+                {
+                    return "AIGreaterThanEqual";
+                }
+
+                virtual bool operator()(ContractionProblem const& problem) const override
+                {
+                    return problem.arithmeticIntensity() >= value;
+                }
+
+                virtual bool debugEval(ContractionProblem const& problem,
+                                       std::ostream&             stream) const override
+                {
+                    bool rv = (*this)(problem);
+
+                    stream << *this << ": (" << problem.arithmeticIntensity() << " >= " << value
+                           << ") == " << rv;
+
+                    return rv;
+                }
+            };
+
+            struct AILessThanEqual : public Predicate_CRTP<AILessThanEqual, ContractionProblem>
+            {
+                enum
+                {
+                    HasIndex = false,
+                    HasValue = true
+                };
+
+                double value;
+
+                AILessThanEqual() = default;
+                AILessThanEqual(double value)
+                    : value(value)
+                {
+                }
+
+                static std::string Type()
+                {
+                    return "AILessThanEqual";
+                }
+
+                virtual bool operator()(ContractionProblem const& problem) const override
+                {
+                    return problem.arithmeticIntensity() <= value;
+                }
+
+                virtual bool debugEval(ContractionProblem const& problem,
+                                       std::ostream&             stream) const override
+                {
+                    bool rv = (*this)(problem);
+
+                    stream << *this << ": (" << problem.arithmeticIntensity() << " <= " << value
+                           << ") == " << rv;
+
+                    return rv;
+                }
+            };
+
             struct AlphaValue : public Predicate_CRTP<AlphaValue, ContractionProblem>
             {
                 enum

--- a/Tensile/Source/lib/include/Tensile/Serialization/ContractionPredicates.hpp
+++ b/Tensile/Source/lib/include/Tensile/Serialization/ContractionPredicates.hpp
@@ -75,6 +75,8 @@ namespace Tensile
                     Base::template Pair<Predicates::Contraction::StrideDEqual>(),
                     Base::template Pair<Predicates::Contraction::LDCEqualsLDD>(),
                     Base::template Pair<Predicates::Contraction::CEqualsD>(),
+                    Base::template Pair<Predicates::Contraction::AIGreaterThanEqual>(),
+                    Base::template Pair<Predicates::Contraction::AILessThanEqual>(),
                     Base::template Pair<Predicates::Contraction::AlphaValue>(),
                     Base::template Pair<Predicates::Contraction::BetaValue>(),
                     Base::template Pair<Predicates::Contraction::BetaZero>(),
@@ -223,6 +225,18 @@ namespace Tensile
         template <typename IO>
         struct MappingTraits<Predicates::Contraction::CEqualsD, IO>
             : public AutoMappingTraits<Predicates::Contraction::CEqualsD, IO>
+        {
+        };
+
+        template <typename IO>
+        struct MappingTraits<Predicates::Contraction::AIGreaterThanEqual, IO>
+            : public AutoMappingTraits<Predicates::Contraction::AIGreaterThanEqual, IO>
+        {
+        };
+
+        template <typename IO>
+        struct MappingTraits<Predicates::Contraction::AILessThanEqual, IO>
+            : public AutoMappingTraits<Predicates::Contraction::AILessThanEqual, IO>
         {
         };
 

--- a/Tensile/Source/lib/source/ContractionProblem.cpp
+++ b/Tensile/Source/lib/source/ContractionProblem.cpp
@@ -1057,10 +1057,6 @@ namespace Tensile
         {
             problemSize *= m_problemSizes[i];
         }
-        for(size_t i = 0; i < m_batchSizes.size(); ++i)
-        {
-            problemSize *= m_batchSizes[i];
-        }
         double gflop = 2 * problemSize * 1e-9;
 
         size_t aSize = 1;

--- a/Tensile/Source/lib/source/ContractionProblem.cpp
+++ b/Tensile/Source/lib/source/ContractionProblem.cpp
@@ -706,6 +706,7 @@ namespace Tensile
             m_beta); // Set enum using beta to potentially allow for faster solutions
         consistencyCheck();
         normalize();
+        calcArithmeticIntensity();
     }
 
     size_t ContractionProblem::toAPos(size_t idx) const
@@ -1047,6 +1048,39 @@ namespace Tensile
         for(auto const& op : m_dOps)
             if(op.type == TensorOp::Type::ComplexConjugate)
                 TENSILE_ASSERT_EXC(DataTypeInfo::Get(m_d.dataType()).isComplex);
+    }
+
+    void ContractionProblem::calcArithmeticIntensity()
+    {
+        size_t problemSize = 1;
+        for(size_t i = 0; i < m_problemSizes.size(); ++i)
+        {
+            problemSize *= m_problemSizes[i];
+        }
+        for(size_t i = 0; i < m_batchSizes.size(); ++i)
+        {
+            problemSize *= m_batchSizes[i];
+        }
+        double gflop = 2 * problemSize * 1e-9;
+
+        size_t aSize = 1;
+        for(size_t i = 0; i < m_a.dimensions(); ++i)
+        {
+            aSize *= m_a.sizes()[i];
+        }
+        size_t bSize = 1;
+        for(size_t i = 0; i < m_b.dimensions(); ++i)
+        {
+            bSize *= m_b.sizes()[i];
+        }
+        size_t cSize = 1;
+        for(size_t i = 0; i < m_c.dimensions(); ++i)
+        {
+            cSize *= m_c.sizes()[i];
+        }
+        double gbyte = (aSize * m_a.elementBytes() + bSize * m_b.elementBytes() + cSize * m_c.elementBytes()) * 1e-9;
+
+        m_arithmeticIntensity = gflop / gbyte;
     }
 
     size_t ContractionProblem::freeSizeA(size_t idx) const

--- a/Tensile/Source/lib/source/ContractionProblem.cpp
+++ b/Tensile/Source/lib/source/ContractionProblem.cpp
@@ -1080,10 +1080,12 @@ namespace Tensile
         }
         if(m_beta != 0) // If problem includes beta, update gflops and gbytes
         {
-            gflop += 2 * cSize * 1e-9;  // Include (+ beta * C) in gflops
-            cSize *= 2;                 // Include read C and write D in gbytes
+            gflop += 2 * cSize * 1e-9; // Include (+ beta * C) in gflops
+            cSize *= 2; // Include read C and write D in gbytes
         }
-        double gbyte = (aSize * m_a.elementBytes() + bSize * m_b.elementBytes() + cSize * m_c.elementBytes()) * 1e-9;
+        double gbyte
+            = (aSize * m_a.elementBytes() + bSize * m_b.elementBytes() + cSize * m_c.elementBytes())
+              * 1e-9;
 
         m_arithmeticIntensity = gflop / gbyte;
     }

--- a/Tensile/Source/lib/source/ContractionProblem.cpp
+++ b/Tensile/Source/lib/source/ContractionProblem.cpp
@@ -1078,6 +1078,11 @@ namespace Tensile
         {
             cSize *= m_c.sizes()[i];
         }
+        if(m_beta != 0) // If problem includes beta, update gflops and gbytes
+        {
+            gflop += 2 * cSize * 1e-9;  // Include (+ beta * C) in gflops
+            cSize *= 2;                 // Include read C and write D in gbytes
+        }
         double gbyte = (aSize * m_a.elementBytes() + bSize * m_b.elementBytes() + cSize * m_c.elementBytes()) * 1e-9;
 
         m_arithmeticIntensity = gflop / gbyte;


### PR DESCRIPTION
Add a new predicate to select kernels based on a problem's arithmetic intensity.

PR in draft mode for now - I need to review arithmetic intensity calculation and account for optional beta. Also trying to find a way to add a test case for this.