### PR TITLE
Update xfail, 1sum tests only failing on gfx90a

### DIFF
--- a/Tensile/Tests/extended/multi_sum_psd/1sum_gsu_simple.yaml
+++ b/Tensile/Tests/extended/multi_sum_psd/1sum_gsu_simple.yaml
@@ -1,5 +1,5 @@
 TestParameters:
-  marks: [xfail]
+  marks: [xfail-gfx90a]
 
 GlobalParameters:
   EnqueuesPerSync: 1

--- a/Tensile/Tests/extended/multi_sum_psd/1sum_simple.yaml
+++ b/Tensile/Tests/extended/multi_sum_psd/1sum_simple.yaml
@@ -1,5 +1,5 @@
 TestParameters:
-  marks: [xfail]
+  marks: [xfail-gfx90a]
 
 GlobalParameters:
   EnqueuesPerSync: 1


### PR DESCRIPTION
1sum tests marked as xfail until compiler bug fix is in mainline build used on CI. The bug does not seem to affect gfx908 since these tests are currently passing on that arch. Update the xfail tags to xfail-gfx90a.