### PR TITLE
DirectToVgpr + packing support, increase extended test timeout

### DIFF
--- a/.jenkins/extended.groovy
+++ b/.jenkins/extended.groovy
@@ -45,7 +45,7 @@ def runCI =
 
     boolean formatCheck = false
 
-    prj.timeout.test = 600
+    prj.timeout.test = 720
     prj.defaults.ccache = false
 
     def commonGroovy

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -1318,7 +1318,8 @@ validParameters = {
     "ExtraMiLatencyLeft":         list(range(0,9,2)),
 
     # Add extra latency to calculate number of MFMA to insert between local read and wait
-    "ExtraLatencyForLR":          list(range(0,17,2)),
+    # Negative value means reduce interval between local read and wait (for DirectToVgpr only)
+    "ExtraLatencyForLR":          list(range(0,17,2)) + list(range(-80,0,10)),
 
     # Allocate dedicated vgpr for local read with packing
     #   False: use tmp vgpr. Less vgpr usage, but not best for local read scheduling

--- a/Tensile/Components/LocalRead.py
+++ b/Tensile/Components/LocalRead.py
@@ -363,4 +363,8 @@ class LocalReadMFMA(LocalRead):
                         elif kernel["ProblemType"]["DataType"].isSingle():
                             localReadCode.addCode(writer.assert_eq( dbgVgpr, 1.0) )
 
+        # DTV case, do not return local read code. Return pack code only.
+        if kernel["DirectToVgpr%s"%tc]:
+          return Code.Module(), pack
+
         return imod, pack

--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -2013,6 +2013,13 @@ class KernelWriter(metaclass=abc.ABCMeta):
     # if this is the last NoLoadLoop(NLLlast) and self.tailLoopInNLL case, set tail=True for mfmaIter
     needTailCode = NLLlast and self.tailLoopInNLL
 
+    # vregSetIdx for DTV
+    # NGLL case, use first set. NLL case, use second set
+    vregSetIdxMFMA = 0 if isNGLL else 1
+    # flip vregSetIdx if isDTVodd is True
+    if isDTVodd:
+      vregSetIdxMFMA = 1 - vregSetIdxMFMA
+
     for uIdx in range(0, kernel["LoopIters"]*kernel["DepthULdsDivisor"]):
       u = uIdx % kernel["LoopIters"]    #   u: index in compute loop (in contrast to the notion of global read loop)
       uDu = uIdx // kernel["LoopIters"] # uDu: index of compute loop
@@ -2072,6 +2079,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
 
       kl.append(self.comment("iter %u%s"%(u,extraComment)))
       plrIdx = ((u+pflr) % (self.numVgprBuffer+1)) % kernel["LoopIters"]
+      plrIdxDTV = (u+pflr) % kernel["LoopIters"]
       localReads = Code.Module()
 
       pointerLWCode = Code.Module()
@@ -2081,12 +2089,23 @@ class KernelWriter(metaclass=abc.ABCMeta):
       waitLWCode = Code.Module()
       syncCode = Code.Module()
 
+      # vregSetIdx for DTV
+      vregSetIdxLR = vregSetIdxMFMA
+      if kernel["LoopIters"] > 1 and u == kernel["LoopIters"] - 1 and \
+         not ( isNGLL and (not isDTVodd) and self.generateDTVodd):
+        # use next vregSet for the last loopIter
+        # exception for isNGLL and not isDTVodd and odd code enabled case
+        # in this case, we need to flip twice (for NGLL to NLL, even to odd)
+        # then, we do not need to flip vregSetIdxLR
+        vregSetIdxLR = 1 - vregSetIdxLR
+
       if self.enable["LocalRead"]:
         hasLiveLdsData = kernel["PrefetchGlobalRead"] or (uDu < kernel["DepthULdsDivisor"]-1)
         hasLiveLdsData = hasLiveLdsData and not isLastLoop
         # for DirectToVgpr + DTVodd
         # need to call localReadDo to allocate tmpVgpr for the next DTVeven case (no actual asm code generated for DTV)
         needExtraLocalReadDo = (NLLlast and isDTVodd and u > localWriteEndIter)
+        # DTV pack case, generate local read code for DTVodd case
         hasLiveLdsData = hasLiveLdsData or needExtraLocalReadDo
         # reads for current loop are done in previous iteration because of wider local read
         doReadA = (u < kernel["LoopIters"]/self.numIterPerCoalescedReadA - self.numItersPLR)
@@ -2094,9 +2113,6 @@ class KernelWriter(metaclass=abc.ABCMeta):
         # reads for next loop
         doReadA = doReadA or (hasLiveLdsData and u > localWriteEndIter)
         doReadB = doReadB or (hasLiveLdsData and u > localWriteEndIter)
-        # disable LocalRead if DirectToVgpr is enabled
-        doReadA = doReadA and (not kernel["DirectToVgprA"])
-        doReadB = doReadB and (not kernel["DirectToVgprB"])
         for iui in range(0,kernel["InnerUnroll"]):
           doReadA = doReadA and iui*self.numReadsIterCoalescedA < kernel["InnerUnroll"]
           doReadB = doReadB and iui*self.numReadsIterCoalescedB < kernel["InnerUnroll"]
@@ -2105,18 +2121,32 @@ class KernelWriter(metaclass=abc.ABCMeta):
             # just need to call localReadDo to allocate tmpVgpr
             if not needExtraLocalReadDo:
               localReads.addText(self.comment("local read a"))
-            localReadCodeA, packCodeA = self.localReadDo(kernel, plrIdx*self.numIterPerCoalescedReadA, iui*self.numReadsIterCoalescedA, 0, tensorParametersA)
+            bufferIdx = plrIdx*self.numIterPerCoalescedReadA
+            if self.packDTVA:
+              # DTV + pack case, offset bufferIdx for local read packing instructions
+              bufferIdx = plrIdxDTV*self.numIterPerCoalescedReadA + vregSetIdxLR * kernel["LoopIters"]
+            localReadCodeA, packCodeA = self.localReadDo(kernel, bufferIdx, iui*self.numReadsIterCoalescedA, 0, tensorParametersA)
             if not needExtraLocalReadDo:
               localReads.addCode(localReadCodeA)
+              pack[plrIdx*self.numIterPerCoalescedReadA].addCode(packCodeA)
+            if needExtraLocalReadDo and (self.packDTVA or self.packDTVB):
+              # packDTV + needExtraLocalReadDo, need to update pack code to flip vregSetIdx
               pack[plrIdx*self.numIterPerCoalescedReadA].addCode(packCodeA)
           if doReadB:
             # needExtraLocalReadDo only case, no need to generate actual code
             # just need to call localReadDo to allocate tmpVgpr
             if not needExtraLocalReadDo:
               localReads.addText(self.comment("local read b"))
-            localReadCodeB, packCodeB = self.localReadDo(kernel, plrIdx*self.numIterPerCoalescedReadB, iui*self.numReadsIterCoalescedB, 0, tensorParametersB)
+            bufferIdx = plrIdx*self.numIterPerCoalescedReadB
+            if self.packDTVB:
+              # DTV + pack case, offset bufferIdx for local read packing instructions
+              bufferIdx = plrIdxDTV*self.numIterPerCoalescedReadB + vregSetIdxLR * kernel["LoopIters"]
+            localReadCodeB, packCodeB = self.localReadDo(kernel, bufferIdx, iui*self.numReadsIterCoalescedB, 0, tensorParametersB)
             if not needExtraLocalReadDo:
               localReads.addCode(localReadCodeB)
+              pack[plrIdx*self.numIterPerCoalescedReadB].addCode(packCodeB)
+            if needExtraLocalReadDo and (self.packDTVA or self.packDTVB):
+              # packDTV + needExtraLocalReadDo, need to update pack code to flip vregSetIdx
               pack[plrIdx*self.numIterPerCoalescedReadB].addCode(packCodeB)
           if (not isResetLroIter or iui != kernel["InnerUnroll"]-1):
             if doReadA:
@@ -2202,13 +2232,6 @@ class KernelWriter(metaclass=abc.ABCMeta):
       luIdx = (u) % (self.numVgprBuffer+1) # local to use for MACs
       if self.enable["MAC"]:
         if kernel["EnableMatrixInstruction"]:
-          # NGLL case, use first set
-          setId = 0 if isNGLL else 1
-          # flip setId if isDTVodd is True
-          if isDTVodd:
-             setId = 1 - setId
-          # use second set for DirectToVGPR
-          vregSetIdxMFMA = setId # use first set for NGLL, second set for other cases
           if ((uIdx+1) == kernel["LoopIters"]*kernel["DepthULdsDivisor"]) and \
               (kernel["StoreCInUnroll"]):
             lastuIdx = (isOptNLL or self.enableSingleNLLOpt) and not isNGLL # do not apply lastuIdx for not isOptNLL case
@@ -2337,9 +2360,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
         kl.append(self.syncThreads(kernel))
 
     # if DirectToVgpr and  ASEM/GSU is not multiple of DepthU*2, generate noLoadLoopBody twice for odd and even exit separately
-    asem = kernel["AssertSummationElementMultiple"]
-    gsu = kernel["GlobalSplitU"]
-    if ( kernel["DirectToVgprA"] or  kernel["DirectToVgprB"]) and ((asem%gsu != 0) or (asem//gsu) % (kernel["DepthU"] * 2) != 0):
+    if self.generateDTVodd:
       # generate additional No Load Loop Body code for odd case (to use the other Vreg set for DirectToVgpr)
       # 1. generate odd check
       name = ""
@@ -2356,8 +2377,8 @@ class KernelWriter(metaclass=abc.ABCMeta):
       # backup
       self.saveLocalPointers(kernel)
       # copy pack
-      if isNGLL:
-        # NGLL case, no deep copy for pack
+      if isNGLL or (self.packDTVA or self.packDTVB):
+        # NGLL or pack DTV case, no deep copy for pack
         # pack code for local prefetch is generated in noLoadLoopBody and used for DTV even
         deepCopyPack = pack
       else: 
@@ -2533,20 +2554,20 @@ class KernelWriter(metaclass=abc.ABCMeta):
         for plrIdx in range(0, self.numItersPLR):
           pack[plrIdx] = Code.Module()
           for iui in range(0,kernel["InnerUnroll"]):
-            if iui*self.numReadsIterCoalescedA < kernel["InnerUnroll"] and (not kernel["DirectToVgprA"]) : # no local read code if DirectToVgpr is enabled
+            if iui*self.numReadsIterCoalescedA < kernel["InnerUnroll"]:
               kl.append(self.comment("prefetch local a"))
               localReadCodeA, packCodeA = self.localReadDo(kernel, plrIdx*self.numIterPerCoalescedReadA, iui*self.numReadsIterCoalescedA, 0, tensorParametersA)
               kl.append(localReadCodeA)
               pack[plrIdx].addCode(packCodeA)
-            if iui*self.numReadsIterCoalescedB < kernel["InnerUnroll"] and (not kernel["DirectToVgprB"]) : # no local read code if DirectToVgpr is enabled
+            if iui*self.numReadsIterCoalescedB < kernel["InnerUnroll"]:
               kl.append(self.comment("prefetch local b"))
               localReadCodeB, packCodeB = self.localReadDo(kernel, plrIdx*self.numIterPerCoalescedReadB, iui*self.numReadsIterCoalescedB, 0, tensorParametersB)
               kl.append(localReadCodeB)
               pack[plrIdx].addCode(packCodeB)
-            if iui*self.numReadsIterCoalescedA < kernel["InnerUnroll"] and (not kernel["DirectToVgprA"]) : # no local read code if DirectToVgpr is enabled
+            if iui*self.numReadsIterCoalescedA < kernel["InnerUnroll"]:
               kl.append(self.comment1("local read increment a"))
               kl.append(self.localReadInc(kernel, iui, tensorParametersA))
-            if iui*self.numReadsIterCoalescedB < kernel["InnerUnroll"]  and (not kernel["DirectToVgprB"]) : # no local read code if DirectToVgpr is enabled
+            if iui*self.numReadsIterCoalescedB < kernel["InnerUnroll"]:
               kl.append(self.comment1("local read increment b"))
               kl.append(self.localReadInc(kernel, iui, tensorParametersB))
 
@@ -2554,6 +2575,8 @@ class KernelWriter(metaclass=abc.ABCMeta):
     kl.append(self.openString(kernel))
 
     pflr     = self.numItersPLR  # how many pf already done above
+    # vregSetIdx for DTV
+    vregSetIdxMFMA = lc
 
     ############################################################################
     # unrolled loop: mac iterations
@@ -2631,6 +2654,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
 
       kl.append(self.comment("iter %u%s"%(u,extraComment)))
       plrIdx = ((u+pflr) % (self.numVgprBuffer+1)) % kernel["LoopIters"]
+      plrIdxDTV = (u+pflr) % kernel["LoopIters"]
 
       localReads = Code.Module()
       localReadsA = Code.Module()
@@ -2643,6 +2667,22 @@ class KernelWriter(metaclass=abc.ABCMeta):
       waitLWCode = Code.Module()
       syncCode = Code.Module()
 
+      # vregSetIdx for DTV
+      vregSetIdxLR = vregSetIdxMFMA
+      if kernel["LoopIters"] > 1 and u == kernel["LoopIters"] - 1:
+        # use next vregSet for the last loopIter (exception: LoopIters==1)
+        # LoopIters==1 case, local read is for the current iteration and not for the next iteration
+        vregSetIdxLR = (vregSetIdxLR + 1) % loopCopies
+        # final loop case, use vregSetIdx for noLoadLoop (NGLL(PGR2) or NLL(PGR1))
+        if finalLoop:
+          # finalLoop case, this is for NoLoadLoop (NGLL(PGR2) or NLL(PGR1))
+          # PGR2 case, next is NGLL. Use first set
+          # PGR1 case, next is NLL. Use second set
+          vregSetIdxLR = 0 if kernel["PrefetchGlobalRead"] == 2 else 1
+          # flip vregSetIdx if isDTVodd is True
+          if self.generateDTVodd:
+            vregSetIdxLR = 1 - vregSetIdxLR
+
       if self.enable["LocalRead"]:
         hasLiveLdsData = kernel["PrefetchGlobalRead"] or (uDu < kernel["DepthULdsDivisor"]-1)
         # reads for current loop are done in previous iteration because of wider local read
@@ -2652,20 +2692,26 @@ class KernelWriter(metaclass=abc.ABCMeta):
         doReadA = doReadA or (hasLiveLdsData and u > localWriteEndIter)
         doReadB = doReadB or (hasLiveLdsData and u > localWriteEndIter)
         # disable LocalRead if DirectToVgpr is enabled
-        doReadA = doReadA and (not kernel["DirectToVgprA"])
-        doReadB = doReadB and (not kernel["DirectToVgprB"])
         for iui in range(0,kernel["InnerUnroll"]):
           doReadA = doReadA and iui*self.numReadsIterCoalescedA < kernel["InnerUnroll"]
           doReadB = doReadB and iui*self.numReadsIterCoalescedB < kernel["InnerUnroll"]
           if doReadA:
             localReads.addText(self.comment("local read a"))
-            localReadCodeA, packCodeA = self.localReadDo(kernel, plrIdx*self.numIterPerCoalescedReadA, iui*self.numReadsIterCoalescedA, 0, tensorParametersA)
+            bufferIdx = plrIdx*self.numIterPerCoalescedReadA
+            if self.packDTVA:
+              # DTV + pack case, offset bufferIdx for local read packing instructions
+              bufferIdx = plrIdxDTV*self.numIterPerCoalescedReadA + vregSetIdxLR * kernel["LoopIters"]
+            localReadCodeA, packCodeA = self.localReadDo(kernel, bufferIdx, iui*self.numReadsIterCoalescedA, 0, tensorParametersA)
             localReads.addCode(localReadCodeA)
             localReadsA.addCode(localReadCodeA)
             pack[plrIdx*self.numIterPerCoalescedReadA].addCode(packCodeA)
           if doReadB:
             localReads.addText(self.comment("local read b"))
-            localReadCodeB, packCodeB = self.localReadDo(kernel, plrIdx*self.numIterPerCoalescedReadB, iui*self.numReadsIterCoalescedB, 0, tensorParametersB)
+            bufferIdx = plrIdx*self.numIterPerCoalescedReadB
+            if self.packDTVB:
+              # DTV + pack case, offset bufferIdx for local read packing instructions
+              bufferIdx = plrIdxDTV*self.numIterPerCoalescedReadB + vregSetIdxLR * kernel["LoopIters"]
+            localReadCodeB, packCodeB = self.localReadDo(kernel, bufferIdx, iui*self.numReadsIterCoalescedB, 0, tensorParametersB)
             localReads.addCode(localReadCodeB)
             localReadsB.addCode(localReadCodeB)
             pack[plrIdx*self.numIterPerCoalescedReadB].addCode(packCodeB)
@@ -2758,7 +2804,6 @@ class KernelWriter(metaclass=abc.ABCMeta):
       luIdx = (u) % (self.numVgprBuffer+1) # local to use for MACs
       if self.enable["MAC"]:
         if kernel["EnableMatrixInstruction"]:
-          vregSetIdxMFMA = lc
           macIterCode.addCode(self.mfmaIter(kernel, u, kernel["InnerUnroll"], vregSetIdxMFMA, firstIter=firstIter and u == 0))
         else:
           macIterCode.addCode(self.macIter(kernel, luIdx, kernel["InnerUnroll"], True ))
@@ -3138,20 +3183,20 @@ class KernelWriter(metaclass=abc.ABCMeta):
             # for espi in range(0, (self.prefetchAcrossPersistent and kernel["ExpandPointerSwap"])+1):
             for espi in range(0, 1):
               for iui in range(0,kernel["InnerUnroll"]):
-                if iui*self.numReadsIterCoalescedA < kernel["InnerUnroll"] and (not kernel["DirectToVgprA"]) : # no local read code if DirectToVgpr is enabled
+                if iui*self.numReadsIterCoalescedA < kernel["InnerUnroll"]:
                   kl.append(self.comment("local read prefetch a"))
                   localReadCodeA, packCodeA = self.localReadDo(kernel, plrIdx*self.numIterPerCoalescedReadA, iui*self.numReadsIterCoalescedA, espi, tensorParametersA)
                   kl.append(localReadCodeA)
                   pack[plrIdx].addCode(packCodeA)
-                if iui*self.numReadsIterCoalescedB < kernel["InnerUnroll"] and (not kernel["DirectToVgprB"]) : # no local read code if DirectToVgpr is enabled
+                if iui*self.numReadsIterCoalescedB < kernel["InnerUnroll"]:
                   kl.append(self.comment("local read prefetch b"))
                   localReadCodeB, packCodeB = self.localReadDo(kernel, plrIdx*self.numIterPerCoalescedReadB, iui*self.numReadsIterCoalescedB, espi, tensorParametersB)
                   kl.append(localReadCodeB)
                   pack[plrIdx].addCode(packCodeB)
-                if iui*self.numReadsIterCoalescedA < kernel["InnerUnroll"] and (not kernel["DirectToVgprA"]) : # no local read code if DirectToVgpr is enabled
+                if iui*self.numReadsIterCoalescedA < kernel["InnerUnroll"]:
                   kl.append(self.comment("local read inc a"))
                   kl.append(self.localReadInc(kernel, iui, tensorParametersA))
-                if iui*self.numReadsIterCoalescedB < kernel["InnerUnroll"] and (not kernel["DirectToVgprB"]) : # no local read code if DirectToVgpr is enabled
+                if iui*self.numReadsIterCoalescedB < kernel["InnerUnroll"]:
                   kl.append(self.comment("local read inc b"))
                   kl.append(self.localReadInc(kernel, iui, tensorParametersB))
       kl.append(self.closeSumAtLeastUnroll(kernel, prefetch=True, isOptNLL=False, isPap=False, isNGLL=False))
@@ -3422,31 +3467,33 @@ class KernelWriter(metaclass=abc.ABCMeta):
               # print tail loop counter if mEnd>1 (means do tail loop unroll)
               kl.append(self.comment("tail loop unroll iter %u"%(mValue)))
             pack[0] = Code.Module()
+            # always use vregSetIdx=0 for DirectToVgpr + tail loop
+            vregSetIdxMFMA = 0
             for iui in range(0, tailLoopInnerUnroll):
               if self.enable["LocalRead"]:
-                doReadA = not kernel["DirectToVgprA"]
-                doReadB = not kernel["DirectToVgprB"]
                 # local read buffer id. No prefetch in tail loop case.
                 bufIdx = (mValue % (self.numVgprBuffer+1)) % kernel["LoopIters"]
-                if mValue*self.numReadsIterCoalescedA < mEnd and doReadA:
+                # DTVpack case, use different bufIdx for all loop iterations
+                bufIdxDTV = mValue % kernel["LoopIters"]
+                bufIdxA = bufIdxDTV if self.packDTVA else bufIdx
+                bufIdxB = bufIdxDTV if self.packDTVB else bufIdx
+                if mValue*self.numReadsIterCoalescedA < mEnd:
                   # Reading 16-bit data from LDS requires packing when ECC enabled
                   kl.append(self.comment("local read a"))
-                  localReadCodeA, packCodeA = self.localReadDo(kernel, bufIdx*self.numIterPerCoalescedReadA, iui*self.numIterPerCoalescedReadA, 0, tensorParametersA)
+                  localReadCodeA, packCodeA = self.localReadDo(kernel, bufIdxA*self.numIterPerCoalescedReadA, iui*self.numIterPerCoalescedReadA, 0, tensorParametersA)
                   kl.append(localReadCodeA)
                   pack[0].addCode(packCodeA)
-                if mValue*self.numReadsIterCoalescedB < mEnd and doReadB:
+                if mValue*self.numReadsIterCoalescedB < mEnd:
                   kl.append(self.comment("local read b"))
-                  localReadCodeB, packCodeB = self.localReadDo(kernel, bufIdx*self.numIterPerCoalescedReadB, iui*self.numIterPerCoalescedReadB, 0, tensorParametersB)
+                  localReadCodeB, packCodeB = self.localReadDo(kernel, bufIdxB*self.numIterPerCoalescedReadB, iui*self.numIterPerCoalescedReadB, 0, tensorParametersB)
                   kl.append(localReadCodeB)
                   pack[0].addCode(packCodeB)
                 # adjustment for DirectToLds case
                 iuiParam = iui + tailLoopInnerUnroll * mValue
-                if doReadA:
-                  kl.append(self.comment("local read inc a"))
-                  kl.append(self.localReadInc(kernel, iuiParam, tensorParametersA))
-                if doReadB:
-                  kl.append(self.comment("local read inc b"))
-                  kl.append(self.localReadInc(kernel, iuiParam, tensorParametersB))
+                kl.append(self.comment("local read inc a"))
+                kl.append(self.localReadInc(kernel, iuiParam, tensorParametersA))
+                kl.append(self.comment("local read inc b"))
+                kl.append(self.localReadInc(kernel, iuiParam, tensorParametersB))
             if self.enable["Wait"]:
               kl.append(self.wait(kernel, tensorParametersA, tensorParametersB, -1, -1, 0, "4wait for local read"))
 
@@ -3748,6 +3795,12 @@ class KernelWriter(metaclass=abc.ABCMeta):
     self.tailLoopInNLL = noTailLoop >= 2
     self.noEarlyExitForTailLoopInNLL = noTailLoop == 3
 
+    # DTV odd check
+    # need DTV odd code if (asem//GSU) is not multiple of DepthU*2
+    self.generateDTVodd = False
+    if ( kernel["DirectToVgprA"] or  kernel["DirectToVgprB"]) and (asemDivGSU % (kernel["DepthU"] * 2) != 0):
+      self.generateDTVodd = True
+
     self.actualSummationLoops = 1 if kernel["PackSummationDims"] else kernel["ProblemType"]["NumIndicesSummation"]
     self.otherSummationLoops  = self.actualSummationLoops-1
     self.otherSummations      = kernel["ProblemType"]["NumIndicesSummation"]-1 # not loops but summations vars
@@ -3895,6 +3948,9 @@ class KernelWriter(metaclass=abc.ABCMeta):
         self.lrvwTileA = min(kernel["MIInputPerThread"], kernel["VectorWidthA"]) # should not exceed MIInputPerThread
       if (not kernel["UnrollMajorLDSB"]):
         self.lrvwTileB = min(kernel["MIInputPerThread"], kernel["VectorWidthB"]) # should not exceed MIInputPerThread
+    # DirectToVgpr + pack (v_perm)
+    self.packDTVA = kernel["DirectToVgprA"] and self.lrvwTileA > 1
+    self.packDTVB = kernel["DirectToVgprB"] and self.lrvwTileB > 1
 
     self.numItersPLR = kernel["PrefetchLocalRead"]%kernel["LoopIters"]
     self.numVgprBuffer = kernel["LoopIters"] if kernel["PrefetchLocalRead"] > kernel["LoopIters"] else kernel["PrefetchLocalRead"]
@@ -4236,7 +4292,11 @@ class KernelWriter(metaclass=abc.ABCMeta):
         self.swapMfmaInnerLoop = True
       if (not kernel["ProblemType"]["DataType"].isComplex()) and kernel["DirectToVgprA"] and kernel["PrefetchGlobalRead"] == 2:
         # not Complex and DTVA + PGR2 case, use B for inner loop to schedule more mfma between DTVA global read instructions
-        self.swapMfmaInnerLoop = True
+        # exception: both A and B pack code case
+        needPackAB = kernel["EnableMatrixInstruction"] and kernel["MIInputPerThread"] > 1 and \
+                   ((not kernel["UnrollMajorLDSA"]) and (not kernel["UnrollMajorLDSB"]))
+        if not needPackAB:
+          self.swapMfmaInnerLoop = True
 
     # init code optimization
     # generate local read/write address code and global read tile offset code before wait for kernel arg load (if applicable)

--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -1496,7 +1496,9 @@ class KernelWriter(metaclass=abc.ABCMeta):
           if count:
             # insert 1 nop instruction
             iterCode.addInst("s_nop ",str(count - 1),"VALU packing writes to be consumed by matrix instruction")
-        if i == numMfmaPerIter - 1:
+        # the final mfma or DirectToVgpr + PGR2 case, we need to generate all remaining pack instructions
+        # otherwise, DTV global load can overwrite pack register values
+        if i == numMfmaPerIter - 1 or len(list(globalReadCodeDTV.items())) > 0:
           while packItems:
             iterCode.addCode(packItems.pop(0))
 

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -1278,7 +1278,11 @@ class KernelWriterAssembly(KernelWriter):
     self.numVgprValuC = (kernel["ThreadTile0"]*kernel["ThreadTile1"]*self.bpeCinternal)//self.bpr
 
     PLR = kernel["PrefetchLocalRead"] if kernel["PrefetchLocalRead"] < kernel["LoopIters"] else kernel["LoopIters"] - 1
-    valuBlocks = (1+PLR) * kernel["InnerUnroll"]
+
+    PLRplus1A = (1+PLR) if not self.packDTVA else kernel["LoopIters"]
+    PLRplus1B = (1+PLR) if not self.packDTVB else kernel["LoopIters"]
+    valuBlocksA = PLRplus1A * kernel["InnerUnroll"]
+    valuBlocksB = PLRplus1B * kernel["InnerUnroll"]
     if kernel["EnableMatrixInstruction"]:
       self.numVgprValuAPerBlock = kernel["MIWaveTileA"] * kernel["MIInputPerThread"] * tPA["bpe"] // self.bpr
       self.numVgprValuBPerBlock = kernel["MIWaveTileB"] * kernel["MIInputPerThread"] * tPB["bpe"] // self.bpr
@@ -1300,13 +1304,13 @@ class KernelWriterAssembly(KernelWriter):
           self.numVgprValuBPerBlock = kernel["ThreadTileB"]
 
     # change numVgprValuAPerBlock to 0 for A if DirectToVgpr is enabled
-    if kernel["DirectToVgprA"]:
+    if kernel["DirectToVgprA"] and not self.packDTVA:
       self.numVgprValuAPerBlock = 0
-    self.numVgprValuA = self.numVgprValuAPerBlock * valuBlocks
+    self.numVgprValuA = self.numVgprValuAPerBlock * valuBlocksA
     # change numVgprValuBPerBlock to 0 for B if DirectToVgpr is enabled
-    if kernel["DirectToVgprB"]:
+    if kernel["DirectToVgprB"] and not self.packDTVB:
       self.numVgprValuBPerBlock = 0
-    self.numVgprValuB = self.numVgprValuBPerBlock * valuBlocks
+    self.numVgprValuB = self.numVgprValuBPerBlock * valuBlocksB
 
     if self.archCaps["HasEccHalf"]:
         self.needPackA = tPA["bpe"] < self.bpr and (not kernel["UnrollMajorLDSA"]) and kernel["EnableMatrixInstruction"]
@@ -1322,11 +1326,14 @@ class KernelWriterAssembly(KernelWriter):
     needVgprForPack = self.needPackA and kernel["VgprForLocalReadPacking"]
     if needVgprForPack:
       if self.lrvwTileA > 1:
-        self.numVgprValuA //= (1+PLR)
+        self.numVgprValuA //= PLRplus1A
         numLoadPerReg = max(1, int(self.numElemPerBprA)//self.lrvwTileA)
-        valuBlocksPack = (1+PLR) * numLoadPerReg
+        valuBlocksPack = PLRplus1A * numLoadPerReg
       else:
-        valuBlocksPack = (int(self.numElemPerBprA) - 1)
+         valuBlocksPack = (int(self.numElemPerBprA) - 1)
+      if self.packDTVA:
+        # pack DTV case, double the number of blocks
+        valuBlocksPack *= 2
       self.numVgprValuPackA = self.numVgprValuA * valuBlocksPack
 
     self.numVgprValuPackB =0
@@ -1334,11 +1341,14 @@ class KernelWriterAssembly(KernelWriter):
     needVgprForPack = self.needPackB and kernel["VgprForLocalReadPacking"]
     if needVgprForPack:
       if self.lrvwTileB > 1:
-        self.numVgprValuB //= (1+PLR)
+        self.numVgprValuB //= PLRplus1B
         numLoadPerReg = max(1, int(self.numElemPerBprB)//self.lrvwTileB)
-        valuBlocksPack = (1+PLR) * numLoadPerReg
+        valuBlocksPack = PLRplus1B * numLoadPerReg
       else:
         valuBlocksPack = (int(self.numElemPerBprB) - 1)
+      if self.packDTVB:
+        # pack DTV case, double the number of blocks
+        valuBlocksPack *= 2
       self.numVgprValuPackB = self.numVgprValuB * valuBlocksPack
 
     ####################################
@@ -1492,9 +1502,13 @@ class KernelWriterAssembly(KernelWriter):
     vgprIdx += self.numVgprValuPackA
     self.startVgprG2LA = None
     if not kernel["DirectToLdsA"] or self.do["KeepDirectToLdsAlloc"]:
+      if self.packDTVA:
+        # DirectToVgpr + packing
+        # overlap G2LA and ValuPackA
+        self.startVgprG2LA = self.startVgprValuPackA
       # if PGR = True, PAP could be possibly enabled, we move G2LA later to prevent it from being reclaimed
       # otherwise, put G2L here since it can overlap valu
-      if not kernel["PrefetchGlobalRead"] and not kernel.enabledSplitLDS: # g2l can overlap valu
+      elif not kernel["PrefetchGlobalRead"] and not kernel.enabledSplitLDS: # g2l can overlap valu
         self.startVgprG2LA = self.startVgprValuA
         vgprIdx = self.startVgprValuA \
             + max(self.numVgprValuA + self.numVgprValuPackA, self.numVgprG2LA)
@@ -1508,9 +1522,13 @@ class KernelWriterAssembly(KernelWriter):
     vgprIdx += self.numVgprValuPackB
     self.startVgprG2LB = None
     if not kernel["DirectToLdsB"] or self.do["KeepDirectToLdsAlloc"]:
+      if self.packDTVB:
+        # DirectToVgpr + packing
+        # overlap G2LB and ValuPackB
+        self.startVgprG2LB = self.startVgprValuPackB
       # if PGR = True, PAP could be possibly enabled, we move G2LB later to prevent it from being reclaimed
       # otherwise, put G2L here since it can overlap valu
-      if not kernel["PrefetchGlobalRead"] and not kernel.enabledSplitLDS: # g2l can overlap valu
+      elif not kernel["PrefetchGlobalRead"] and not kernel.enabledSplitLDS: # g2l can overlap valu
         self.startVgprG2LB = self.startVgprValuB
         vgprIdx = self.startVgprValuB \
             + max(self.numVgprValuB + self.numVgprValuPackB, self.numVgprG2LB)
@@ -2585,7 +2603,11 @@ class KernelWriterAssembly(KernelWriter):
     numBi = PLR+1
     ri = 0
     if self.numVgprValuA > 0: # Do not generate vgprValuA if numVgprValuA is 0
-      for bi in range(0,numBi): # buffer indices
+      numBiFactor = numBi
+      if kernel["DirectToVgprA"] and self.lrvwTileA > 1:
+        # DirectToVgpr case, we need LoopIters * 2 buffers
+        numBiFactor = kernel["LoopIters"] * 2
+      for bi in range(0,numBiFactor): # buffer indices
         for iui in range(0, kernel["InnerUnroll"]):
           kStr += self.macroRegister("vgprValuA_X%u_I%u"%(bi,iui), self.startVgprValuA+ri)
           ri += self.numVgprValuAPerBlock
@@ -2594,9 +2616,9 @@ class KernelWriterAssembly(KernelWriter):
       if self.numVgprValuPackA > 0:
         ri = 0
         if self.lrvwTileA > 1:
-          for data in range(0,kernel["MIInputPerThread"]):
-            for bi in range(0,numBi): # buffer indices
-              for iui in range(0, kernel["InnerUnroll"]):
+          for bi in range(0,numBiFactor): # buffer indices
+            for iui in range(0, kernel["InnerUnroll"]):
+              for data in range(0,kernel["MIInputPerThread"]):
                 kStr += self.macroRegister("vgprValuA_X%u_I%u_D%u"%(bi,iui,data), self.startVgprValuPackA+ri)
                 ri += ceil(self.lrvwTileA * self.tPA["bpe"] / self.bpr) * kernel["MIWaveTileA"] // self.lrvwTileA
         else:
@@ -2614,7 +2636,11 @@ class KernelWriterAssembly(KernelWriter):
 
     ri = 0
     if self.numVgprValuB > 0: # Do not generate vgprValuB if numVgprValuB is 0
-      for bi in range(0,numBi): # buffer indices
+      numBiFactor = numBi
+      if kernel["DirectToVgprB"] and self.lrvwTileB > 1:
+        # DirectToVgpr case, we need LoopIters * 2 buffers
+        numBiFactor = kernel["LoopIters"] * 2
+      for bi in range(0,numBiFactor): # buffer indices
         for iui in range(0, kernel["InnerUnroll"]):
           kStr += self.macroRegister("vgprValuB_X%u_I%u"%(bi,iui), self.startVgprValuB+ri)
           ri += self.numVgprValuBPerBlock
@@ -2623,14 +2649,14 @@ class KernelWriterAssembly(KernelWriter):
       if self.numVgprValuPackB > 0:
         ri = 0
         if self.lrvwTileB > 1:
-          for data in range(0,kernel["MIInputPerThread"]):
-            for bi in range(0,numBi): # buffer indices
-              for iui in range(0, kernel["InnerUnroll"]):
+          for bi in range(0,numBiFactor): # buffer indices
+            for iui in range(0, kernel["InnerUnroll"]):
+              for data in range(0,kernel["MIInputPerThread"]):
                 kStr += self.macroRegister("vgprValuB_X%u_I%u_D%u"%(bi,iui,data), self.startVgprValuPackB+ri)
                 ri += ceil(self.lrvwTileB * self.tPB["bpe"] / self.bpr) * kernel["MIWaveTileB"] // self.lrvwTileB
         else:
           for data in range(1,int(self.numElemPerBprB)):
-            for bi in range(0,numBi): # buffer indices
+            for bi in range(0,numBiFactor): # buffer indices
               for iui in range(0, kernel["InnerUnroll"]):
                 kStr += self.macroRegister("vgprValuB_X%u_I%u_D%u"%(bi,iui,data), self.startVgprValuPackB+ri)
                 ri += self.numVgprValuBPerBlock
@@ -4077,6 +4103,9 @@ class KernelWriterAssembly(KernelWriter):
       dividendReg = self.vgprPool.checkOut(1, "idInWave", self.preventVgprOverflowDuringNewTile)
       kStr += vectorStaticRemainder(dividendReg, "Serial", divisorVal, tmpSgpr)
 
+    # store DirectToVgpr K interval for later use
+    dtvKInterval = 1
+
     if kernel["DirectToVgpr%s"%tc]:
       # offset calculation for DirectToVgpr
       # ported code from local read for DirectToVgpr
@@ -4161,7 +4190,11 @@ class KernelWriterAssembly(KernelWriter):
       tluOther = kernel["ProblemType"]["TLUB"] if tP["isA"] else kernel["ProblemType"]["TLUA"] # The other side of tlu
       if lrvwOther >= 2 and (not tluOther) and tP["tlu"]:
         # DirectToVgpr + LocalReadVectorWidth>=2 case, multiply qReg by lrvwOther
-        kStr += staticMultiply(vgpr(qReg), vgpr(qReg), lrvwOther, sgpr(tmpSgpr))
+        dtvKInterval = lrvwOther
+      if  tluOther and tP["tlu"]:
+        # DirectToVgpr + both TLU case, multiply qReg by kernel["MIInputPerThread"]
+        dtvKInterval = kernel["MIInputPerThread"]
+      kStr += staticMultiply(vgpr(qReg), vgpr(qReg), dtvKInterval, sgpr(tmpSgpr))
 
     else:
       divisor2 = divisor
@@ -4230,6 +4263,12 @@ class KernelWriterAssembly(KernelWriter):
     tP["gpr"]["lwoT"] = tReg
     tP["gpr"]["tReg"] = tReg2
     tP["gpr"]["uReg"] = uReg
+
+    # store DirectToVgpr K interval for later use
+    if tP["isA"]:
+      self.dtvKIntervalA = dtvKInterval
+    else:
+      self.dtvKIntervalB = dtvKInterval
 
     return "" if self.dontAppendCode else kStr
 
@@ -4420,47 +4459,47 @@ class KernelWriterAssembly(KernelWriter):
       stride = kernel[strideIdx]
       prevStride = 0
       totalStride = 0
-      lrvwOther = self.lrvwB if tP["isA"] else self.lrvwA # The other side of lrvw
-      tluOther = kernel["ProblemType"]["TLUB"] if tP["isA"] else kernel["ProblemType"]["TLUA"] # The other side of tlu
       bpeOffset = 1 if tP["glvw"] >= 1 else tP["bpe"] # glvw<1 case, need to multiply strideValue by bpe
+      dtvKInterval = self.dtvKIntervalA if tP["isA"] else self.dtvKIntervalB
+
       if tP["ruc"]:
         # l=0, s=0
         kStr += inst("v_mov_b32", vgpr(v), \
-            vgpr(tP["gpr"]["uReg"]), "gro%s%s_%u_s%u"%(tP["tensorChar"], self.unrollChar, 0, 0) )
+            vgpr(tP["gpr"]["uReg"]), "gro%s%s_%u_s%u"%(tc, self.unrollChar, 0, 0) )
         # l=0, s>0
         for s in range(1, tP["glvw"]):
           kStr += inst("_v_add_co_u32", vgpr(v+s), self.vcc, 1, \
-              vgpr(v+s-1), "gro%s%s_%u_s%u"%(tP["tensorChar"], self.unrollChar, 0, s) )
+              vgpr(v+s-1), "gro%s%s_%u_s%u"%(tc, self.unrollChar, 0, s) )
         for l in range(1, tP["nru"]):
           # l>0, s=0
           totalStride += stride
-          if  tP["tlu"] and kernel["DirectToVgpr%s"%tc] and lrvwOther >= 2 and not tluOther:
-            # DirectToVgpr + LocalReadVectorWidth>=2 + other side of TLU is false case, stride * lrvwOther is added every lrvwOther. 
+          if dtvKInterval > 1:
+            # DirectToVgpr + k interval > 1 case, stride * dtvKInterval is added every dtvKInterval. 
             # Add mod in mod != 0 case
-            totalStride = stride * (l - (l % lrvwOther)) + (l % lrvwOther)
+            totalStride = stride * (l - (l % dtvKInterval)) + (l % dtvKInterval)
           currStride = totalStride - prevStride
           prevStride = totalStride
           kStr += inst("_v_add_co_u32", vgpr(v+l*tP["glvw"]), self.vcc, currStride * bpeOffset, \
               vgpr(v+(l-1)*tP["glvw"]), \
-              "gro%s%s_%u_s%u + %s"%(tP["tensorChar"], self.unrollChar, l, 0, strideIdx) )
+              "gro%s%s_%u_s%u + %s"%(tc, self.unrollChar, l, 0, strideIdx) )
           # l>0, s>0
           for s in range(1, tP["glvw"]):
             kStr += inst("_v_add_co_u32", vgpr(v+l*tP["glvw"]+s), self.vcc, \
                 1, vgpr(v+l*tP["glvw"]+(s-1)), \
-                "gro%s%s_%u_s%u"%(tP["tensorChar"], self.unrollChar, 0, s) )
+                "gro%s%s_%u_s%u"%(tc, self.unrollChar, 0, s) )
       else:
         kStr += inst("v_mov_b32", vgpr(v), \
-            vgpr(tP["gpr"]["uReg"]), "gro%s%s_%u"%(tP["tensorChar"], self.unrollChar, 0) )
+            vgpr(tP["gpr"]["uReg"]), "gro%s%s_%u"%(tc, self.unrollChar, 0) )
         for l in range(1, tP["nru"]):
           totalStride += stride
-          if tP["tlu"] and kernel["DirectToVgpr%s"%tc] and lrvwOther >= 2 and not tluOther:
-            # DirectToVgpr + LocalReadVectorWidth>=2 case, stride * lrvwOther is added every lrvwOther.
+          if dtvKInterval > 1:
+            # DirectToVgpr + k interval > 1 case, stride * dtvKInterval is added every dtvKInterval. 
             # Add mod in mod != 0 case
-            totalStride = stride * (l - (l % lrvwOther)) + (l % lrvwOther)
+            totalStride = stride * (l - (l % dtvKInterval)) + (l % dtvKInterval)
           currStride = totalStride - prevStride
           prevStride = totalStride
           kStr += inst("_v_add_co_u32", vgpr(v+l), self.vcc, currStride * bpeOffset, \
-              vgpr(v+l-1), "gro%s%s_%u + %s"%(tP["tensorChar"], self.unrollChar, l, strideIdx) )
+              vgpr(v+l-1), "gro%s%s_%u + %s"%(tc, self.unrollChar, l, strideIdx) )
       #self.vgprPool.checkIn(tP["gpr"]["uReg"])
     return "" if self.dontAppendCode else kStr
 
@@ -6994,13 +7033,21 @@ class KernelWriterAssembly(KernelWriter):
     m_or_u = u if kernel["DirectToVgpr%c"%tc] else m
     vgprBuffer_new = (m_or_u//numIterPerCoalescedRead)*numIterPerCoalescedRead
     vgprBuffer_new_offset = m_or_u%numIterPerCoalescedRead*innerUnroll*vgprPerInput
+    # DirectToVgpr + pack special case
+    # offset vgprBuffer_new
+    packDTV = self.packDTVA if tc == "A" else self.packDTVB
+    if packDTV:
+      # DTV + pack case, offset bufferIdx for local read packing instructions
+      numBi = kernel["LoopIters"]
+      vgprBuffer_new += vregSetIdx * numBi
 
     iui_new = (iui//numReadsIterCoalesced)*numReadsIterCoalesced
     iui_new_offset = iui%numReadsIterCoalesced*vgprPerInput
     ab_new = idxAB*vgprPerInput*numReadsIterCoalesced
     abStr = "Valu%c_X%u_I%u+%u+%u+%u" % (tc, vgprBuffer_new, iui_new, ab_new, vgprBuffer_new_offset, iui_new_offset)
-    if kernel["DirectToVgpr%c"%tc]:
-      # overwrite aStr/bStr for DirectToVgpr
+    packDTV = self.packDTVA if tP["isA"] else self.packDTVB
+    if kernel["DirectToVgpr%c"%tc] and not packDTV:
+      # overwrite aStr/bStr for DirectToVgpr (except for pack DTV case)
       ab_new += vregSetIdx * numVgprPerBlock + ( vgprBuffer_new * innerUnroll) * numVgprValuPerBlock
       abStr  = "G2L%c+%u+%u" % (tc, ab_new, vgprBuffer_new_offset)
 

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -2221,14 +2221,16 @@ class Solution(collections.abc.Mapping):
     while grvw >= minGrvw:
       # Per instruction across the entire group:
       elementsLoadedPerInst = state["NumThreads"]*grvw
+      mik = 1
       if (state["DirectToVgpr%s"%tc] and state["ProblemType"]["TLU%s"%tc]):
-        elementsLoadedPerInst //= state["MatrixInstK"] * state["LocalSplitU"]
+        mik = state["MatrixInstK"] * state["LocalSplitU"] // state["MIInputPerThread"]
+        elementsLoadedPerInst //= mik
       # LSC, LSP - #elements loaded along specified dim with each load
       if parDim >= elementsLoadedPerInst:
         # entire work-group can work on (part) of the same row
         # DirectToVgpr case, LSC is limited to elementsLoadedPerInst // (state["MatrixInstK"] * state["LocalSplitU"])
         state["LSC%s"%tc] = elementsLoadedPerInst
-        state["LSP%s"%tc] = 1 if not (state["DirectToVgpr%s"%tc] and state["ProblemType"]["TLU%s"%tc]) else state["MatrixInstK"] * state["LocalSplitU"]
+        state["LSP%s"%tc] = mik
         state["NumLoadsCoalesced%s"%tc] = roundupRatio(parDim , state["LSC%s"%tc])
         state["NumLoadsPerpendicular%s"%tc] = 1
       else:
@@ -2249,9 +2251,7 @@ class Solution(collections.abc.Mapping):
         validElementsLoadedPerInst = state["LSC%s"%tc] * state["LSP%s"%tc]
         grvw //= 2
         while grvw >= minGrvw:
-          elementsLoadedPerInst = state["NumThreads"]*grvw
-          if state["DirectToVgpr%s"%tc] and state["ProblemType"]["TLU%s"%tc]:
-            elementsLoadedPerInst //= state["MatrixInstK"] * state["LocalSplitU"]
+          elementsLoadedPerInst = state["NumThreads"]*grvw//mik
           if elementsLoadedPerInst < validElementsLoadedPerInst:
             break # Went too far, not enough load elements at this VW
           if state["LSC%s"%tc] % grvw == 0:
@@ -2427,6 +2427,30 @@ class Solution(collections.abc.Mapping):
 
 
   ########################################
+  # determine can we use VgprForLocalReadPacking
+  @staticmethod
+  def isVgprForLocalReadPackingDoable(state):
+    rejectComment = ""
+    doable = True
+    # MatrixInstruction only
+    if not state["EnableMatrixInstruction"]:
+      rejectComment = "VgprForLocalReadPacking is for MatrixInstruction only"
+      doable = False
+    # only for HasEccHalf
+    if not globalParameters["ArchCaps"][globalParameters["CurrentISA"]]["HasEccHalf"]:
+      rejectComment = "VgprForLocalReadPacking is for EccHalf only"
+      doable = False
+    # only for SIA=3 + PLR>=1
+    if not (state["ScheduleIterAlg"] == 3 and state["PrefetchLocalRead"] >= 1):
+      rejectComment = "VgprForLocalReadPacking is effective only fof SIA=3 and PLR>=1"
+      doable = False
+    # only for 1 or 2 byte input (numRegister < 1) + UnrollMajorLDSA or B is False
+    if not (state["ProblemType"]["DataType"].numRegisters() < 1 and (state["UnrollMajorLDSA"] == False or state["UnrollMajorLDSB"] == False)):
+      rejectComment = "VgprForLocalReadPacking is effective only fof 1 or 2 byte input + UnrollMajorLDSA or B =false"
+      doable = False
+    return doable, rejectComment
+
+  ########################################
   # determine if current datatype can support DirectToVgpr
   @staticmethod
   def isDirectToVgprSupportDataType(state):
@@ -2470,8 +2494,16 @@ class Solution(collections.abc.Mapping):
     if numBytes < 4:
       # Does not work with TLU = True and numBytes < 4 (not supported)
       if state["ProblemType"]["TLU%c"%tc]:
-        reject(state, "DirectToVgpr%c does not supports TLU%c = True + numByte < 4"%(tc, tc))
-        return False
+        doable, _ = Solution.isVgprForLocalReadPackingDoable(state)
+        if numBytes * state["VectorWidth%s"%tc] >= 4 and doable:
+          # use pack logic (with v_perm) same as local read (only if VgprForLocalReadPacking is doable)
+          # numBytes * VW should be 4 or larger
+          # force VgprForLocalReadPacking + ClusterLocalRead
+          state["VgprForLocalReadPacking"] = True
+          state["ClusterLocalRead"] = True
+        else:
+          reject(state, "DirectToVgpr%c does not supports TLU%c = True + numByte < 4"%(tc, tc))
+          return False
 
     # MIWaveGroup, MatrixInstBM,BN check
     #  for A, MIWaveGroup[1] and MatrixInstBN should be 1
@@ -2854,6 +2886,10 @@ class Solution(collections.abc.Mapping):
           reject(state, "didn't support LdsBlockSizePerPad in VALU mode yet")
 
       assert(state["LdsPad%s"%tc] >= 0)
+
+      # DirectToVgpr case, set LdsPad to 0
+      if state["DirectToVgpr%s"%tc]:
+        state["LdsPad%s"%tc] = 0
 
       # set LdsBlockSizePerPad = 0 if LdsPad is 0
       if state["LdsPad%s"%tc] == 0:
@@ -4594,22 +4630,10 @@ class Solution(collections.abc.Mapping):
 
     # reject check for VgprForLocalReadPacking
     if state["VgprForLocalReadPacking"]:
-        # MatrixInstruction only
-        if not state["EnableMatrixInstruction"]:
-          reject(state, "VgprForLocalReadPacking is for MatrixInstruction only")
-          return
-        # only for HasEccHalf
-        if not globalParameters["ArchCaps"][globalParameters["CurrentISA"]]["HasEccHalf"]:
-          reject(state, "VgprForLocalReadPacking is for EccHalf only")
-          return
-        # only for SIA=3 + PLR>=1
-        if not (state["ScheduleIterAlg"] == 3 and state["PrefetchLocalRead"] >= 1):
-          reject(state, "VgprForLocalReadPacking is effective only fof SIA=3 and PLR>=1")
-          return
-        # only for 1 or 2 byte input (numRegister < 1) + UnrollMajorLDSA or B is False
-        if not (state["ProblemType"]["DataType"].numRegisters() < 1 and (state["UnrollMajorLDSA"] == False or state["UnrollMajorLDSB"] == False)):
-          reject(state, "VgprForLocalReadPacking is effective only fof 1 or 2 byte input + UnrollMajorLDSA or B =false")
-          return
+      doable, rejectComment = Solution.isVgprForLocalReadPackingDoable(state)
+      if not doable:
+        reject(state, rejectComment)
+        return
 
     # reject check for ClusterLocalRead
     if state["ClusterLocalRead"]:
@@ -4621,6 +4645,10 @@ class Solution(collections.abc.Mapping):
            (state["UnrollMajorLDSB"] == False and state["VectorWidthB"] > state["MIInputPerThread"]):
           reject(state, "ClusterLocalRead does not support VectorWidth or VectorWidthB > MIInputPerThread")
           return
+
+    # change negative ExtraLatencyForLR to 0 for non DirectToVgpr
+    if state["ExtraLatencyForLR"] < 0 and not (state["DirectToVgprA"] or state["DirectToVgprB"]):
+      state["ExtraLatencyForLR"] = 0
 
   ########################################
   # create a dictionary with booleans on whether to include parameter in name

--- a/Tensile/Tests/extended/direct_to_vgpr/dtv_f8gemm.yaml
+++ b/Tensile/Tests/extended/direct_to_vgpr/dtv_f8gemm.yaml
@@ -121,7 +121,226 @@ BenchmarkProblems:
         - ProblemSizes:
           - Exact: [ 508, 508, 1, 2048]
 
+  ########################################
+  # F8SS NT - DTVA + DTL
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: F8
+      DestDataType: S
+      ComputeDataType: S
+      HighPrecisionAccumulate: True
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+    -
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+            - [16, 16, 32, 1, 1, 4, 4, 4,1]  # 256x64
+            - [16, 16, 32, 1, 1, 8, 4, 4,1]  # 512x64
+        #- ThreadTile:
+        #  - [ 2, 2 ]
+        - WorkGroup:
+          - [ 64, 1, 1 ] # only WG2 is effective for 9 parameter MI
+          #- [ 64, 1, 2 ] # only WG2 is effective for 9 parameter MI
+          #- [ 64, 1, 4 ] # only WG2 is effective for 9 parameter MI
+        - AssertFree0ElementMultiple : [4]
+        - AssertFree1ElementMultiple : [4]
+        - AssertSummationElementMultiple: [128]
+        - DepthU: [64,128]
+        - 1LDSBuffer: [0]
+        - LoopTail: [True]
+        - OptNoLoadLoop: [1]
+        - PrefetchGlobalRead: [1,2]
+        - PrefetchLocalRead: [1,2,3,5,9,17]
+        - ScheduleIterAlg: [3]
+        - StaggerU: [0]
+        - SourceSwap: [1]
+        #- TransposeLDS: [1]
+        - GlobalReadVectorWidth: [4,8]
+        - LocalReadVectorWidth: [4,8]
+        - VectorWidth: [4]
+        #- WaveSeparateGlobalReadB: [1]
+        - NumElementsPerBatchStore: [4]
+        - UseSgprForGRO: [0]
+        - DirectToVgprA: [1]
+        #- DirectToLdsA: [False, True]
+        - DirectToLdsB: [False, True]
+        #- NumLoadsCoalescedA: [1,2,4]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [ 508, 508, 1, 2048]
+
+  ########################################
+  # F8SS NT - DTVB + DTL
+  ########################################
+    -
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+            - [16, 16, 32, 1, 1, 4, 4, 1, 4]  # 64x256
+            - [16, 16, 32, 1, 1, 4, 8, 1, 4]  # 64x512
+        #- ThreadTile:
+        #  - [ 2, 2 ]
+        - WorkGroup:
+          - [ 64, 1, 1 ] # only WG2 is effective for 9 parameter MI
+          #- [ 64, 1, 2 ] # only WG2 is effective for 9 parameter MI
+          #- [ 64, 1, 4 ] # only WG2 is effective for 9 parameter MI
+        - AssertFree0ElementMultiple : [4]
+        - AssertFree1ElementMultiple : [4]
+        - AssertSummationElementMultiple: [128]
+        - DepthU: [64,128]
+        - 1LDSBuffer: [0]
+        - LoopTail: [True]
+        - OptNoLoadLoop: [1]
+        - PrefetchGlobalRead: [1,2]
+        - PrefetchLocalRead: [1,2,3,5,9,17]
+        - ScheduleIterAlg: [3]
+        - StaggerU: [0]
+        - SourceSwap: [1]
+        #- TransposeLDS: [1]
+        - GlobalReadVectorWidth: [4,8]
+        - LocalReadVectorWidth: [4,8]
+        - VectorWidth: [4]
+        #- WaveSeparateGlobalReadB: [1]
+        - NumElementsPerBatchStore: [4]
+        - UseSgprForGRO: [0]
+        - DirectToVgprB: [1]
+        - DirectToLdsA: [False, True]
+        #- DirectToLdsB: [False, True]
+        #- NumLoadsCoalescedA: [1,2,4]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [ 508, 508, 1, 2048]
+
+  ########################################
+  # F8SS NN - DTVA + DTL
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: F8
+      DestDataType: S
+      ComputeDataType: S
+      HighPrecisionAccumulate: True
+      TransposeA: False
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+    -
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+            - [16, 16, 32, 1, 1, 4, 4, 4,1]  # 256x64
+            - [16, 16, 32, 1, 1, 8, 4, 4,1]  # 512x64
+        #- ThreadTile:
+        #  - [ 2, 2 ]
+        - WorkGroup:
+          - [ 64, 1, 1 ] # only WG2 is effective for 9 parameter MI
+          #- [ 64, 1, 2 ] # only WG2 is effective for 9 parameter MI
+          #- [ 64, 1, 4 ] # only WG2 is effective for 9 parameter MI
+        - AssertFree0ElementMultiple : [4]
+        - AssertFree1ElementMultiple : [4]
+        - AssertSummationElementMultiple: [128]
+        - DepthU: [64,128]
+        - 1LDSBuffer: [0]
+        - LoopTail: [True]
+        - OptNoLoadLoop: [1]
+        - PrefetchGlobalRead: [1,2]
+        - PrefetchLocalRead: [1,2,3,5,9,17]
+        - ScheduleIterAlg: [3]
+        - StaggerU: [0]
+        - SourceSwap: [1]
+        - TransposeLDS: [1]
+        - GlobalReadVectorWidth: [4,8]
+        - LocalReadVectorWidth: [4,8]
+        - VectorWidth: [4]
+        #- WaveSeparateGlobalReadB: [1]
+        - NumElementsPerBatchStore: [4]
+        - UseSgprForGRO: [0]
+        - DirectToVgprA: [1]
+        #- DirectToLdsA: [False, True]
+        - DirectToLdsB: [False, True]
+        #- NumLoadsCoalescedA: [1,2,4]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [ 508, 508, 1, 2048]
 
 
+  ########################################
+  # F8SS TT - DTVB + DTL
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: F8
+      DestDataType: S
+      ComputeDataType: S
+      HighPrecisionAccumulate: True
+      TransposeA: True
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+    -
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - EdgeType: ["ShiftPtr"]
+        - LoopTail: [True]
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+            - [16, 16, 32, 1, 1, 4, 4, 1, 4]  # 64x256
+            - [16, 16, 32, 1, 1, 4, 8, 1, 4]  # 64x512
+        #- ThreadTile:
+        #  - [ 2, 2 ]
+        - WorkGroup:
+          - [ 64, 1, 1 ] # only WG2 is effective for 9 parameter MI
+          #- [ 64, 1, 2 ] # only WG2 is effective for 9 parameter MI
+          #- [ 64, 1, 4 ] # only WG2 is effective for 9 parameter MI
+        - AssertFree0ElementMultiple : [4]
+        - AssertFree1ElementMultiple : [4]
+        - AssertSummationElementMultiple: [128]
+        - DepthU: [64,128]
+        - 1LDSBuffer: [0]
+        - LoopTail: [True]
+        - OptNoLoadLoop: [1]
+        - PrefetchGlobalRead: [1,2]
+        - PrefetchLocalRead: [1,2,3,5,9,17]
+        - ScheduleIterAlg: [3]
+        - StaggerU: [0]
+        - SourceSwap: [1]
+        - TransposeLDS: [1]
+        - GlobalReadVectorWidth: [4,8]
+        - LocalReadVectorWidth: [4,8]
+        - VectorWidth: [4]
+        #- WaveSeparateGlobalReadB: [1]
+        - NumElementsPerBatchStore: [4]
+        - UseSgprForGRO: [0]
+        - DirectToVgprB: [1]
+        - DirectToLdsA: [False, True]
+        #- DirectToLdsB: [False, True]
+        #- NumLoadsCoalescedA: [1,2,4]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [ 508, 508, 1, 2048]
 
 

--- a/Tensile/Tests/extended/direct_to_vgpr/dtv_hgemm.yaml
+++ b/Tensile/Tests/extended/direct_to_vgpr/dtv_hgemm.yaml
@@ -354,7 +354,7 @@ BenchmarkProblems:
           - Range: [ [511], [511], [1], [2023, 24, 2047] ]
   
   ########################################
-  # HHS NN - DTVB (+ DTL) + max load width for TailLoopp + VFLRP
+  # HHS NN - DTVB (+ DTL) + max load width for TailLoop + VFLRP
   ########################################
   -
     - # ProblemType
@@ -474,3 +474,263 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Range: [ [511], [511], [1], [2023, 24, 2047] ]
+
+  ########################################
+  # HHS NN - DTVA (+ DTL) + max load width for TailLoop + VFLRP
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: H
+      DestDataType: H
+      ComputeDataType: S
+      HighPrecisionAccumulate: True
+      TransposeA: False
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+    -
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - EdgeType: ["ShiftPtr"]
+        - KernelLanguage: ["Assembly"]
+        - MinKForGSU: [64]
+      ForkParameters:
+        - MatrixInstruction:
+            - [16, 16, 16, 1, 1, 2, 4, 4,1]  # 128x 64
+            - [16, 16, 16, 1, 1, 4, 4, 2,1]  # 128x 64
+            - [16, 16, 16, 1, 1, 4, 4, 4,1]  # 256x 64
+            - [32, 32,  8, 1, 1, 2, 4, 4,1]  # 256x128
+        #- ThreadTile:
+        #  - [ 2, 2 ]
+        - WorkGroup:
+          - [ 64, 1, 1 ] # only WG2 is effective for 9 parameter MI
+          - [ 64, 1, 2 ] # only WG2 is effective for 9 parameter MI
+          #- [ 64, 1, 4 ] # only WG2 is effective for 9 parameter MI
+        - AssertFree0ElementMultiple : [8]
+        - AssertFree1ElementMultiple : [8]
+        - AssertSizeGreaterThan: [{}, {3: 192}]
+        - AssertSummationElementMultiple: [8, 64]
+        - DepthU: [32,64]
+        - 1LDSBuffer: [0]
+        - PrefetchGlobalRead: [1,2]
+        - PrefetchLocalRead: [1,3,5,9]
+        - ScheduleIterAlg: [3]
+        #- StaggerU: [0,32]
+        - SourceSwap: [1]#[0,1]
+        - TransposeLDS: [1]
+        - GlobalReadVectorWidth: [2,4]
+        - LocalReadVectorWidth: [4]#[4,8]
+        - VectorWidth: [2,4]
+        - UseSgprForGRO: [0]
+        - DirectToVgprA: [0,1]
+        #- DirectToLdsA: [False, True]
+        - DirectToLdsB: [False, True]
+        - NumLoadsCoalescedB: [1]
+        #- BufferLoad: [0,1]
+        - GlobalSplitU: [1,2]
+        - GlobalSplitUAlgorithm: ["MultipleBuffer"]
+        - VgprForLocalReadPacking: [1]
+        - ClusterLocalRead: [1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [504], [504], [1], [2024, 8, 2040] ]
+          - Range: [ [504], [504], [1], [200] ]
+          - Range: [ [504], [504], [1], [192] ]
+
+  ########################################
+  # HHS NT - DTVA (+ DTL) + max load width for TailLoop + VFLRP
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: H
+      DestDataType: H
+      ComputeDataType: S
+      HighPrecisionAccumulate: True
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+    -
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - EdgeType: ["ShiftPtr"]
+        - KernelLanguage: ["Assembly"]
+        - MinKForGSU: [64]
+      ForkParameters:
+        - MatrixInstruction:
+            - [16, 16, 16, 1, 1, 2, 4, 4,1]  # 128x 64
+            - [16, 16, 16, 1, 1, 4, 4, 2,1]  # 128x 64
+            - [16, 16, 16, 1, 1, 4, 4, 4,1]  # 256x 64
+            - [32, 32,  8, 1, 1, 2, 4, 4,1]  # 256x128
+        #- ThreadTile:
+        #  - [ 2, 2 ]
+        - WorkGroup:
+          - [ 64, 1, 1 ] # only WG2 is effective for 9 parameter MI
+          - [ 64, 1, 2 ] # only WG2 is effective for 9 parameter MI
+          #- [ 64, 1, 4 ] # only WG2 is effective for 9 parameter MI
+        - AssertFree0ElementMultiple : [8]
+        - AssertFree1ElementMultiple : [8]
+        - AssertSizeGreaterThan: [{}, {3: 192}]
+        - AssertSummationElementMultiple: [8, 64]
+        - DepthU: [32,64]
+        - 1LDSBuffer: [0]
+        - PrefetchGlobalRead: [1,2]
+        - PrefetchLocalRead: [1,3,5,9]
+        - ScheduleIterAlg: [3]
+        #- StaggerU: [0,32]
+        - SourceSwap: [1]#[0,1]
+        #- TransposeLDS: [1]
+        - GlobalReadVectorWidth: [2,4]
+        - LocalReadVectorWidth: [4]#[4,8]
+        - VectorWidth: [2,4]
+        - VectorWidthB: [2,4]
+        - UseSgprForGRO: [0]
+        - DirectToVgprA: [0,1]
+        #- DirectToLdsA: [False, True]
+        - DirectToLdsB: [False, True]
+        - NumLoadsCoalescedB: [1]
+        #- BufferLoad: [0,1]
+        - GlobalSplitU: [1,2]
+        - GlobalSplitUAlgorithm: ["MultipleBuffer"]
+        - VgprForLocalReadPacking: [1]
+        - ClusterLocalRead: [1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [504], [504], [1], [2024, 8, 2040] ]
+          - Range: [ [504], [504], [1], [200] ]
+          - Range: [ [504], [504], [1], [192] ]
+
+  ########################################
+  # HHS NT - DTVB (+ DTL) + max load width for TailLoop + VFLRP
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: H
+      DestDataType: H
+      ComputeDataType: S
+      HighPrecisionAccumulate: True
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+    -
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - EdgeType: ["ShiftPtr"]
+        - KernelLanguage: ["Assembly"]
+        - MinKForGSU: [64]
+      ForkParameters:
+        - MatrixInstruction:
+            #- [16, 16, 16, 1, 1, 4, 2, 1, 4]  #  64x128
+            - [16, 16, 16, 1, 1, 4, 4, 1, 2]  #  64x128
+            - [16, 16, 16, 1, 1, 4, 4, 1, 4]  #  64x256
+            - [32, 32,  8, 1, 1, 4, 2, 1, 4]  # 128x256
+        #- ThreadTile:
+        #  - [ 2, 2 ]
+        - WorkGroup:
+          - [ 64, 1, 1 ] # only WG2 is effective for 9 parameter MI
+          - [ 64, 1, 2 ] # only WG2 is effective for 9 parameter MI
+          #- [ 64, 1, 4 ] # only WG2 is effective for 9 parameter MI
+        - AssertFree0ElementMultiple : [8]
+        - AssertFree1ElementMultiple : [8]
+        - AssertSizeGreaterThan: [{}, {3: 192}]
+        - AssertSummationElementMultiple: [8, 64]
+        - DepthU: [32,64]
+        - 1LDSBuffer: [0]
+        - PrefetchGlobalRead: [1,2]
+        - PrefetchLocalRead: [1,3,5,9]
+        - ScheduleIterAlg: [3]
+        #- StaggerU: [0,32]
+        - SourceSwap: [1]#[0,1]
+        #- TransposeLDS: [1]
+        - GlobalReadVectorWidth: [2,4]
+        - LocalReadVectorWidth: [4]#[4,8]
+        - VectorWidth: [2,4]
+        - VectorWidthB: [2,4]
+        - UseSgprForGRO: [0]
+        - DirectToVgprB: [0,1]
+        - DirectToLdsA: [False, True]
+        #- DirectToLdsB: [False, True]
+        - NumLoadsCoalescedB: [1]
+        #- BufferLoad: [0,1]
+        #- GlobalSplitU: [1,2]
+        #- GlobalSplitUAlgorithm: ["MultipleBuffer"]
+        - VgprForLocalReadPacking: [1]
+        - ClusterLocalRead: [1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [504], [504], [1], [2024, 8, 2040] ]
+          - Range: [ [504], [504], [1], [200] ]
+          - Range: [ [504], [504], [1], [192] ]
+
+  ########################################
+  # HHS TT - DTVB (+ DTL) + max load width for TailLoop + VFLRP
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: H
+      DestDataType: H
+      ComputeDataType: S
+      HighPrecisionAccumulate: True
+      TransposeA: True
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+    -
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - EdgeType: ["ShiftPtr"]
+        - KernelLanguage: ["Assembly"]
+        - MinKForGSU: [64]
+      ForkParameters:
+        - MatrixInstruction:
+            #- [16, 16, 16, 1, 1, 4, 2, 1, 4]  #  64x128
+            - [16, 16, 16, 1, 1, 4, 4, 1, 2]  #  64x128
+            - [16, 16, 16, 1, 1, 4, 4, 1, 4]  #  64x256
+            - [32, 32,  8, 1, 1, 4, 2, 1, 4]  # 128x256
+        #- ThreadTile:
+        #  - [ 2, 2 ]
+        - WorkGroup:
+          - [ 64, 1, 1 ] # only WG2 is effective for 9 parameter MI
+          - [ 64, 1, 2 ] # only WG2 is effective for 9 parameter MI
+          #- [ 64, 1, 4 ] # only WG2 is effective for 9 parameter MI
+        - AssertFree0ElementMultiple : [8]
+        - AssertFree1ElementMultiple : [8]
+        - AssertSizeGreaterThan: [{}, {3: 192}]
+        - AssertSummationElementMultiple: [8, 64]
+        - DepthU: [32,64]
+        - 1LDSBuffer: [0]
+        - PrefetchGlobalRead: [1,2]
+        - PrefetchLocalRead: [1,3,5,9]
+        - ScheduleIterAlg: [3]
+        #- StaggerU: [0,32]
+        - SourceSwap: [1]#[0,1]
+        - TransposeLDS: [1]
+        - GlobalReadVectorWidth: [2,4]
+        - LocalReadVectorWidth: [4]#[4,8]
+        - VectorWidth: [2,4]
+        - VectorWidthB: [2,4]
+        - UseSgprForGRO: [0]
+        - DirectToVgprB: [0,1]
+        - DirectToLdsA: [False, True]
+        #- DirectToLdsB: [False, True]
+        - NumLoadsCoalescedB: [1]
+        #- BufferLoad: [0,1]
+        #- GlobalSplitU: [1,2]
+        #- GlobalSplitUAlgorithm: ["MultipleBuffer"]
+        - VgprForLocalReadPacking: [1]
+        - ClusterLocalRead: [1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [504], [504], [1], [2024, 8, 2040] ]
+          - Range: [ [504], [504], [1], [200] ]
+          - Range: [ [504], [504], [1], [192] ]
+


### PR DESCRIPTION
- enabled DirectToVgpr + packing for f8/f16 + TLU cases
- enabled negative values for ExtraLatencyForLR to reduce interval of local read and wait for DTV
- added test cases for DirectToVgpr + packing
- increased extended test timeout to 720 min