### PR TITLE
Skip DTV, DTL, LSU+MFMA tests for gfx908

### DIFF
--- a/Tensile/Tests/extended/direct_to_lds/dtl_hgemm.yaml
+++ b/Tensile/Tests/extended/direct_to_lds/dtl_hgemm.yaml
@@ -1,5 +1,5 @@
 TestParameters:
-  marks: [skip-gfx900, skip-gfx906, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
 
 GlobalParameters:
   NumElementsToValidate: -1

--- a/Tensile/Tests/extended/direct_to_lds/dtl_sgemm.yaml
+++ b/Tensile/Tests/extended/direct_to_lds/dtl_sgemm.yaml
@@ -1,5 +1,5 @@
 TestParameters:
-  marks: [skip-gfx900, skip-gfx906, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
 
 GlobalParameters:
   NumElementsToValidate: -1

--- a/Tensile/Tests/extended/direct_to_lds/dtl_tsgr_hgemm.yaml
+++ b/Tensile/Tests/extended/direct_to_lds/dtl_tsgr_hgemm.yaml
@@ -1,5 +1,5 @@
 TestParameters:
-  marks: [skip-gfx900, skip-gfx906, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
 
 GlobalParameters:
   NumElementsToValidate: -1

--- a/Tensile/Tests/extended/direct_to_lds/dtl_tsgr_sgemm.yaml
+++ b/Tensile/Tests/extended/direct_to_lds/dtl_tsgr_sgemm.yaml
@@ -1,5 +1,5 @@
 TestParameters:
-  marks: [skip-gfx900, skip-gfx906, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
 
 GlobalParameters:
   NumElementsToValidate: -1

--- a/Tensile/Tests/extended/direct_to_vgpr/dtv_hgemm.yaml
+++ b/Tensile/Tests/extended/direct_to_vgpr/dtv_hgemm.yaml
@@ -1,5 +1,5 @@
 TestParameters:
-  marks: [skip-gfx900, skip-gfx906, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
 
 GlobalParameters:
   NumElementsToValidate: -1

--- a/Tensile/Tests/extended/direct_to_vgpr/dtv_igemm.yaml
+++ b/Tensile/Tests/extended/direct_to_vgpr/dtv_igemm.yaml
@@ -1,5 +1,5 @@
 TestParameters:
-  marks: [skip-gfx900, skip-gfx906, skip-gfx940, skip-gfx941, skip-gfx942, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx940, skip-gfx941, skip-gfx942, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
 
 GlobalParameters:
   NumElementsToValidate: -1

--- a/Tensile/Tests/extended/local_split_u/cgemm_lsu_mfma.yaml
+++ b/Tensile/Tests/extended/local_split_u/cgemm_lsu_mfma.yaml
@@ -1,5 +1,5 @@
 TestParameters:
-  marks: [skip-gfx900, skip-gfx906, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
 
 GlobalParameters:
   NumElementsToValidate: -1
@@ -112,7 +112,7 @@ BenchmarkProblems:
         #- AssertFree1ElementMultiple: [1,2]
         - PrefetchLocalRead: [3,5,9]
         - GlobalSplitU: [1,4]
-        - GlobalSplitUAlgorithm: ["SingleBuffer","MultipleBuffer"]
+        - GlobalSplitUAlgorithm: ["SingleBuffer"]#["SingleBuffer","MultipleBuffer"]
         - DepthU:  [16]#[16,32]#[ 8, 16 ]
         #- StoreVectorWidth: [1,2]
         - VectorWidth: [1,2]

--- a/Tensile/Tests/extended/local_split_u/hgemm_lsu_mfma.yaml
+++ b/Tensile/Tests/extended/local_split_u/hgemm_lsu_mfma.yaml
@@ -1,5 +1,5 @@
 TestParameters:
-  marks: [skip-gfx900, skip-gfx906, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
 
 GlobalParameters:
   NumElementsToValidate: -1
@@ -148,7 +148,7 @@ BenchmarkProblems:
         - AssertSummationElementMultiple: [2]
         - DepthU: [32,64,128]#[8,16,32]
         - GlobalSplitU: [1,4]
-        - GlobalSplitUAlgorithm: ["SingleBuffer","MultipleBuffer"]
+        - GlobalSplitUAlgorithm: ["SingleBuffer"]#["SingleBuffer","MultipleBuffer"]
         - 1LDSBuffer: [0]
         - LoopTail: [True]
         - OptNoLoadLoop: [1]
@@ -216,7 +216,7 @@ BenchmarkProblems:
         - AssertSummationElementMultiple: [2]
         - DepthU: [32,64,128]#[8,16,32]
         - GlobalSplitU: [1,4]
-        #- GlobalSplitUAlgorithm: ["SingleBuffer","MultipleBuffer"]
+        - GlobalSplitUAlgorithm: ["SingleBuffer"]#["SingleBuffer","MultipleBuffer"]
         - 1LDSBuffer: [0]
         - LoopTail: [True]
         - OptNoLoadLoop: [1]

--- a/Tensile/Tests/extended/local_split_u/hgemm_lsu_mfma_a1b0.yaml
+++ b/Tensile/Tests/extended/local_split_u/hgemm_lsu_mfma_a1b0.yaml
@@ -1,5 +1,5 @@
 TestParameters:
-  marks: [skip-gfx900, skip-gfx906, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
 
 GlobalParameters:
   NumElementsToValidate: -1

--- a/Tensile/Tests/extended/local_split_u/igemm_lsu_mfma.yaml
+++ b/Tensile/Tests/extended/local_split_u/igemm_lsu_mfma.yaml
@@ -1,5 +1,5 @@
 TestParameters:
-  marks: [skip-gfx900, skip-gfx906, skip-gfx940, skip-gfx941, skip-gfx942, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx940, skip-gfx941, skip-gfx942, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
 
 GlobalParameters:
   NumElementsToValidate: -1
@@ -54,7 +54,7 @@ BenchmarkProblems:
         - AssertSummationElementMultiple: [2]
         - DepthU: [32,64,128]#[8,16,32]
         - GlobalSplitU: [1,4]
-        #- GlobalSplitUAlgorithm: ["SingleBuffer","MultipleBuffer"]
+        - GlobalSplitUAlgorithm: ["SingleBuffer"]#["SingleBuffer","MultipleBuffer"]
         - 1LDSBuffer: [0]
         - LoopTail: [True]
         - OptNoLoadLoop: [1]
@@ -124,7 +124,7 @@ BenchmarkProblems:
         - UseSgprForGRO: [0]
         #- BufferLoad: [0,1]
         #- BufferStore: [0,1]
-        - VgprForLocalReadPacking: [0,1]
+        - VgprForLocalReadPacking: [1]#[0,1]
         - ClusterLocalRead: [0,1]
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
@@ -229,7 +229,7 @@ BenchmarkProblems:
         - AssertSummationElementMultiple: [2]
         - DepthU: [32,64,128]#[8,16,32]
         - GlobalSplitU: [1,4]
-        #- GlobalSplitUAlgorithm: ["SingleBuffer","MultipleBuffer"]
+        - GlobalSplitUAlgorithm: ["SingleBuffer"]#["SingleBuffer","MultipleBuffer"]
         - 1LDSBuffer: [0]
         - LoopTail: [True]
         - OptNoLoadLoop: [1]
@@ -249,7 +249,7 @@ BenchmarkProblems:
         #- BufferLoad: [0,1]
         #- BufferStore: [0,1]
         - TransposeLDS: [1]
-        - LocalReadVectorWidth: [-1,8]
+        - LocalReadVectorWidth: [-1]#[-1,8]
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
@@ -285,7 +285,7 @@ BenchmarkProblems:
         - AssertSummationElementMultiple: [2]
         - DepthU: [32,64,128]#[8,16,32]
         - GlobalSplitU: [1,4]
-        #- GlobalSplitUAlgorithm: ["SingleBuffer","MultipleBuffer"]
+        - GlobalSplitUAlgorithm: ["SingleBuffer"]#["SingleBuffer","MultipleBuffer"]
         - 1LDSBuffer: [0]
         - LoopTail: [True]
         - OptNoLoadLoop: [1]
@@ -305,9 +305,9 @@ BenchmarkProblems:
         #- BufferLoad: [0,1]
         #- BufferStore: [0,1]
         - TransposeLDS: [1]
-        - LocalReadVectorWidth: [-1,8]
+        - LocalReadVectorWidth: [-1]#[-1,8]
         - DirectToVgprB: [0,1]
-        - VgprForLocalReadPacking: [0,1]
+        - VgprForLocalReadPacking: [1]#[0,1]
         - ClusterLocalRead: [0,1]
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
@@ -360,7 +360,7 @@ BenchmarkProblems:
         - AssertSummationElementMultiple: [2]
         - DepthU: [32,64,128]#[8,16,32]
         - GlobalSplitU: [1,4]
-        #- GlobalSplitUAlgorithm: ["SingleBuffer","MultipleBuffer"]
+        - GlobalSplitUAlgorithm: ["SingleBuffer"]#["SingleBuffer","MultipleBuffer"]
         - 1LDSBuffer: [0]
         - LoopTail: [True]
         - OptNoLoadLoop: [1]
@@ -380,7 +380,7 @@ BenchmarkProblems:
         #- BufferLoad: [0,1]
         #- BufferStore: [0,1]
         - TransposeLDS: [1]
-        - LocalReadVectorWidth: [-1,8]
+        - LocalReadVectorWidth: [-1]#[-1,8]
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:

--- a/Tensile/Tests/extended/local_split_u/sgemm_lsu_mfma.yaml
+++ b/Tensile/Tests/extended/local_split_u/sgemm_lsu_mfma.yaml
@@ -1,5 +1,5 @@
 TestParameters:
-  marks: [skip-gfx900, skip-gfx906, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
 
 GlobalParameters:
   NumElementsToValidate: -1
@@ -93,7 +93,7 @@ BenchmarkProblems:
           - [ 64, 1, 4 ] # only WG2 is effective for 9 parameter MI
         - DepthU: [16,32]
         - GlobalSplitU: [1,4]
-        - GlobalSplitUAlgorithm: ["SingleBuffer","MultipleBuffer"]
+        - GlobalSplitUAlgorithm: ["SingleBuffer"]#["SingleBuffer","MultipleBuffer"]
         - GlobalSplitUWorkGroupMappingRoundRobin: [False]
         - GlobalSplitUSummationAssignmentRoundRobin:  [True]
         - 1LDSBuffer: [0]
@@ -146,7 +146,7 @@ BenchmarkProblems:
           - [ 64, 1, 4 ] # only WG2 is effective for 9 parameter MI
         - DepthU: [16]
         - GlobalSplitU: [1,4]
-        #- GlobalSplitUAlgorithm: ["SingleBuffer","MultipleBuffer"]
+        - GlobalSplitUAlgorithm: ["MultipleBuffer"]#["SingleBuffer","MultipleBuffer"]
         #- GlobalSplitUWorkGroupMappingRoundRobin: [False]
         #- GlobalSplitUSummationAssignmentRoundRobin:  [True]
         - 1LDSBuffer: [0]
@@ -329,8 +329,8 @@ BenchmarkProblems:
         - DepthU: [16,32]
         #- GlobalSplitU: [1,2]
         #- GlobalSplitUAlgorithm: ["SingleBuffer","MultipleBuffer"]
-        - GlobalSplitUWorkGroupMappingRoundRobin: [False]
-        - GlobalSplitUSummationAssignmentRoundRobin:  [True]
+        #- GlobalSplitUWorkGroupMappingRoundRobin: [False]
+        #- GlobalSplitUSummationAssignmentRoundRobin:  [True]
         - 1LDSBuffer: [0]
         - LdsBlockSizePerPadA: [-1]
         - LdsBlockSizePerPadB: [-1]


### PR DESCRIPTION
- add skip for gfx908 in the following extended test cases, DTV, DTL, LSU+MFMA
- small refactoring for extended LSU+GSU cases