### PR TITLE
Revert "Use fallback libraries for archs without optimized logic (#1862)"

### DIFF
--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -940,18 +940,11 @@ def generateLogicDataAndSolutions(logicFiles, args):
     # logicData[problemType].append((scheduleName, deviceNames, \
     #     solutionsForSchedule, indexOrder, exactLogic, rangeLogic ))
 
-  (archs, _) = splitArchs()
   if globalParameters["SeparateArchitectures"] or globalParameters["LazyLibraryLoading"]:
     if "fallback" in masterLibraries.keys():
       for key, value in masterLibraries.items():
         if key != "fallback":
           value.merge(deepcopy(masterLibraries["fallback"]))
-      for archName in archs:
-        archName = archName.split('-', 1)[0]
-        if archName not in masterLibraries:
-          print1("Using fallback for arch: " + archName)
-          masterLibraries[archName] = deepcopy(masterLibraries["fallback"])
-          masterLibraries[archName].version = args.version
 
       masterLibraries.pop("fallback")
 


### PR DESCRIPTION
This reverts commit efbe0c0caeedcf03776ae4e6a0067d88e38da211.