### PR TITLE
Disable InitAccVgprOpt for Stream-K

### DIFF
--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -4257,7 +4257,8 @@ class KernelWriter(metaclass=abc.ABCMeta):
     self.useInitAccVgprOpt = False
     # enable for the following conditions
     if kernel["EnableMatrixInstruction"] and (kernel["PrefetchGlobalRead"] == 1 or kernel["PrefetchGlobalRead"] == 2) \
-       and globalParameters["AsmCaps"][globalParameters["CurrentISA"]]["HasMFMA_constSrc"]:
+       and globalParameters["AsmCaps"][globalParameters["CurrentISA"]]["HasMFMA_constSrc"] \
+       and kernel["StreamK"] == 0:
       self.useInitAccVgprOpt = True
     # force to disable for the following conditions
     if self.useInitAccVgprOpt:


### PR DESCRIPTION
Stream-K can split partial tiles at any iteration, and cannot guarantee the minimum number of iterations needed for InitAccVgprOpt