### PR TITLE
Skip stream-k init kernel when possible

### DIFF
--- a/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -1580,7 +1580,9 @@ namespace Tensile
             size += partialTileSize(skGrid);
             // Add space for flags
             // Flags for partial tiles - dword per flag for fast addressing and comparisons
-            size += skGrid * 4;
+            // If tiles is evenly divided by grid size flags are not needed (DP mode)
+            if(tiles % skGrid != 0)
+                size += skGrid * 4;
             // size *= batches; // TODO need tile and flag per batch
         }
         else

--- a/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -1228,11 +1228,18 @@ namespace Tensile
 
         if(sizeMapping.streamK >= 2)
         {
-            if(debug)
-                rv.push_back(generateStreamKInitCall<TypedInputs, true>(problem, inputs, hardware));
-            else
-                rv.push_back(
-                    generateStreamKInitCall<TypedInputs, false>(problem, inputs, hardware));
+            auto   tiles  = problem.getNumTiles(sizeMapping);
+            size_t skGrid = getSKGrid(hardware, tiles);
+            // If problem can run full data-parallel, flags are not needed since there is no fixup step
+            // Skipping init kernel when flags are not needed saves significant time for small problems
+            if(tiles % skGrid != 0)
+            {
+                if(debug)
+                    rv.push_back(generateStreamKInitCall<TypedInputs, true>(problem, inputs, hardware));
+                else
+                    rv.push_back(
+                        generateStreamKInitCall<TypedInputs, false>(problem, inputs, hardware));
+            }
         }
 
         if(sizeMapping.streamK == 1

--- a/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -1235,7 +1235,8 @@ namespace Tensile
             if(tiles % skGrid != 0)
             {
                 if(debug)
-                    rv.push_back(generateStreamKInitCall<TypedInputs, true>(problem, inputs, hardware));
+                    rv.push_back(
+                        generateStreamKInitCall<TypedInputs, true>(problem, inputs, hardware));
                 else
                     rv.push_back(
                         generateStreamKInitCall<TypedInputs, false>(problem, inputs, hardware));


### PR DESCRIPTION
If the number of workgroups evenly divides the number of tiles, the problem runs in full data-parallel mode and no fixup step is necessary. This means that flags are never set or checked so we can skip the init kernel for these cases. This makes a noticeable impact on performance of small sizes where the launch of a per-kernel impacts overall run-time.