### PR TITLE
Use fallback libraries for archs without optimized logic (v2)

### DIFF
--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -943,11 +943,19 @@ def generateLogicDataAndSolutions(logicFiles, args):
     # logicData[problemType].append((scheduleName, deviceNames, \
     #     solutionsForSchedule, indexOrder, exactLogic, rangeLogic ))
 
+  (archs, _) = splitArchs()
   if globalParameters["SeparateArchitectures"] or globalParameters["LazyLibraryLoading"]:
     if "fallback" in masterLibraries.keys():
       for key, value in masterLibraries.items():
         if key != "fallback":
           value.insert(deepcopy(masterLibraries["fallback"]))
+      for archName in archs:
+        archName = archName.split('-', 1)[0]
+        if archName not in masterLibraries:
+          print1("Using fallback for arch: " + archName)
+          masterLibraries[archName] = deepcopy(masterLibraries["fallback"])
+          masterLibraries[archName].version = args.version
+
       masterLibraries.pop("fallback")
 
     for _, masterLibrary in masterLibraries.items():


### PR DESCRIPTION
Fixes #1757. Reintroducing #1862.

Enables architectures that don't have optimized logic files to also produce libraries when `--separate-architectures` or `--lazy-library-loading` is turned on. Previously, one must disable both of these two flags in order for rocBLAS to run on architectures like `gfx1010`.

Previously, there was a bug in Tensile solution indexing that caused #1862 to be reverted. Now, it seems like this issue has been fixed in #1888.

<!--
Testing still needed. It seems like I cannot build the current rocBLAS develop branch (5937a87d) with ROCm 6.0. All one has to do is to run the following in the rocBLAS repo:

```
cmake -GNinja -B build -S . \
    -DCMAKE_C_COMPILER=hipcc \
    -DCMAKE_CXX_COMPILER=hipcc \
    -DBUILD_CLIENTS_TESTS=ON \
    -DBUILD_CLIENTS_BENCHMARKS=OFF \
    -DBUILD_CLIENTS_SAMPLES=OFF \
    -DBUILD_WITH_TENSILE=ON \
    -DTensile_PRINT_DEBUG=ON \
    -DTensile_LIBRARY_FORMAT=msgpack \
    -DTensile_LAZY_LIBRARY_LOADING=ON \
    -DAMDGPU_TARGETS="gfx1010;<your-architecture>" \
    -DTensile_TEST_LOCAL_PATH=$PATH_TO_LOCAL_TENSILE_WITH_THIS_PR
```
(so if your architecture is `gfx1030`, you should use `-DAMDGPU_TARGETS="gfx1010;gfx1030"`)

Then build rocBLAS
```
cmake --build build
```

Then run tests to see if any tests fail.
-->

Test plan:
```
cmake -GNinja -B build -S . \
    -DCMAKE_C_COMPILER=hipcc \
    -DCMAKE_CXX_COMPILER=hipcc \
    -DBUILD_CLIENTS_TESTS=ON \
    -DBUILD_CLIENTS_BENCHMARKS=OFF \
    -DBUILD_CLIENTS_SAMPLES=OFF \
    -DBUILD_TESTING=ON \
    -DBUILD_WITH_TENSILE=ON \
    -DTensile_PRINT_DEBUG=ON \
    -DTensile_LIBRARY_FORMAT=msgpack \
    -DTensile_CPU_THREADS=14 \
    -DTensile_LAZY_LIBRARY_LOADING=ON \
    -DAMDGPU_TARGETS="..."
```
With `AMDGPU_TARGETS` being one of the following
- `AMDGPU_TARGETS=gfx1010`
- `AMDGPU_TARGETS=gfx1030;gfx1010`

In all cases,
`$ROCM_PATH/lib/rocblas/library/TensileLibrary_lazy_gfx1010.dat` is produced
and all other `*.dat` files remain unchanged.

In the second case, `./build/clients/staging/rocblas-test --gtest_filter='*gemm_ex_get_solutions*'` that previously failed now passes. I cannot run the full test suite due to limited memory on my GPU (I often get hipOutOfMemory when running stress tests). If this PR doesn't cause extra failures on AMD's CI or if someone can run the full test suite to ensure no additional failures are introduced, then I believe this PR should be good to go. Hopefully this PR can make it in before ROCm 6.1.
