### PR TITLE
New dynamic mode 

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -1130,6 +1130,7 @@ validParameters = {
     #   problems to a subset based on the number of output tiles.
     #   0 = off (default)
     #   1 = on
+    #   2 = also reduce CUs used for large sizes to improve data-parallel portion and reduce power
     # TENSILE_STREAMK_MAX_CUS allows the user to manually set maximum number of CUs used, which could free up some CUs for
     #   other operations to run in parallel with gemm.
     #   0 = use all CUs (default)

--- a/Tensile/Source/lib/include/Tensile/AMDGPU.hpp
+++ b/Tensile/Source/lib/include/Tensile/AMDGPU.hpp
@@ -225,7 +225,7 @@ namespace Tensile
         const int getSKDynamicGrid() const
         {
             static const char* envStr = std::getenv("TENSILE_STREAMK_DYNAMIC_GRID");
-            static const int   value  = (envStr == NULL ? 0 : (std::atoi(envStr) == 0 ? 0 : 1));
+            static const int   value  = (envStr == NULL ? 0 : std::atoi(envStr));
             return value;
         }
 

--- a/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -1597,6 +1597,21 @@ namespace Tensile
         assert(pAMDGPU != nullptr && pAMDGPU->computeUnitCount != 0);
         size_t cuCount = pAMDGPU->computeUnitCount;
         size_t skGrid  = cuCount;
+        if(pAMDGPU->skDynamicGrid == 2 && tiles > skGrid)
+        {
+            for(size_t i = 1; i <= 32; i *= 2)
+            {
+                size_t tilesPerCU = CeilDivide(i * tiles, skGrid);
+                size_t reducedGrid = CeilDivide(i * tiles, tilesPerCU);
+                float utilization = ((float)reducedGrid) / ((float)skGrid);
+                if(utilization > 0.75f)
+                {
+                    if(utilization < 1.0f)
+                        skGrid = reducedGrid;
+                    break;
+                }
+            }
+        }
         if(pAMDGPU->skMaxCUs > 0)
             skGrid = min(skGrid, pAMDGPU->skMaxCUs);
         if(pAMDGPU->skDynamicGrid)

--- a/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -1601,9 +1601,9 @@ namespace Tensile
         {
             for(size_t i = 1; i <= 32; i *= 2)
             {
-                size_t tilesPerCU = CeilDivide(i * tiles, skGrid);
+                size_t tilesPerCU  = CeilDivide(i * tiles, skGrid);
                 size_t reducedGrid = CeilDivide(i * tiles, tilesPerCU);
-                float utilization = ((float)reducedGrid) / ((float)skGrid);
+                float  utilization = ((float)reducedGrid) / ((float)skGrid);
                 if(utilization > 0.75f)
                 {
                     if(utilization < 1.0f)


### PR DESCRIPTION
New dynamic mode to run large problems at slightly reduced CU count if it improves work division and power. New mode can be enabled by setting environment variable TENSILE_STREAMK_DYNAMIC_GRID=2.
Option is still being benchmarked and evaluated for best use, but initial tests indicate this option should improve stream-k kernel performance on gfx942.