### PR TITLE
Env variable to test fixed grid size with SK kernels

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -1136,6 +1136,8 @@ validParameters = {
     #   0 = use all CUs (default)
     # TENSILE_STREAMK_GRID_MULTIPLIER lets you set how many workgroups are created per CU being used.
     #   1 = 1 WG per CU (default)
+    # TENSILE_STREAMK_FIXED_GRID lets you override the default grid size with a specific number
+    #   0 = override disabled (default)
     "StreamK": [0, 1, 2, 3],
 
     # 0  : standard launch

--- a/Tensile/Source/lib/include/Tensile/AMDGPU.hpp
+++ b/Tensile/Source/lib/include/Tensile/AMDGPU.hpp
@@ -207,6 +207,7 @@ namespace Tensile
         int         skDynamicGrid    = 0;
         int         skMaxCUs         = 0;
         int         skGridMultiplier = 1;
+        int         skFixedGrid      = 0;
         std::string deviceName;
 
         virtual bool   runsKernelTargeting(Processor p) const;
@@ -240,6 +241,13 @@ namespace Tensile
         {
             static const char* envStr = std::getenv("TENSILE_STREAMK_GRID_MULTIPLIER");
             static const int   value  = (envStr == NULL ? 1 : std::atoi(envStr));
+            return value;
+        }
+
+        const int getSKFixedGrid() const
+        {
+            static const char* envStr = std::getenv("TENSILE_STREAMK_FIXED_GRID");
+            static const int   value  = (envStr == NULL ? 0 : std::atoi(envStr));
             return value;
         }
 

--- a/Tensile/Source/lib/source/AMDGPU.cpp
+++ b/Tensile/Source/lib/source/AMDGPU.cpp
@@ -43,6 +43,7 @@ namespace Tensile
         , skDynamicGrid(getSKDynamicGrid())
         , skMaxCUs(getSKMaxCUs())
         , skGridMultiplier(getSKGridMultiplier())
+        , skFixedGrid(getSKFixedGrid())
     {
     }
 
@@ -55,6 +56,7 @@ namespace Tensile
         , skDynamicGrid(getSKDynamicGrid())
         , skMaxCUs(getSKMaxCUs())
         , skGridMultiplier(getSKGridMultiplier())
+        , skFixedGrid(getSKFixedGrid())
     {
     }
 

--- a/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -1604,6 +1604,8 @@ namespace Tensile
     size_t ContractionSolution::getSKGrid(Hardware const& hardware, size_t tiles) const
     {
         AMDGPU const* pAMDGPU = dynamic_cast<AMDGPU const*>(&hardware);
+        if(pAMDGPU->skFixedGrid > 0)
+            return pAMDGPU->skFixedGrid;
         assert(pAMDGPU != nullptr && pAMDGPU->computeUnitCount != 0);
         size_t cuCount = pAMDGPU->computeUnitCount;
         size_t skGrid  = cuCount;


### PR DESCRIPTION
Small change to add another environment variable to make testing and benchmarking stream-k performance easier.