### PR TITLE
Atomic 2-tile strean-k and tuning parameter clean-up

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -1120,9 +1120,8 @@ validParameters = {
     # Total work units are calculated as (#MTs x #LoopIters) and divided among workgroups
     # In most cases each workgroup will calculate a partial tile that are accumulated in a fixup step in the same kernel
     # 0: Standard data-parallel kernel
-    # 1: Basic StreamK atomic (uses atomics to accumulate partial tiles)
-    # 2: Basic StreamK non-atomic (uses workspace to store partial tiles, accumulate in deterministic fix-up step)
-    # 3: Two-Tile StreamK (non-atomic, each WG completes an even number of sk iterations, followed by an even number of dp tiles)
+    # 1: Basic StreamK
+    # 2: Two-Tile StreamK (each WG completes an even number of sk iterations, followed by an even number of dp tiles)
     # StreamK kernels can adjust the number of CUs being used.
     # Using fewer sometimes increases overall throughput by allowing other kernels to run in parallel.
     # StreamK grid is controlled by setting these enviornment variables:
@@ -1138,7 +1137,11 @@ validParameters = {
     #   1 = 1 WG per CU (default)
     # TENSILE_STREAMK_FIXED_GRID lets you override the default grid size with a specific number
     #   0 = override disabled (default)
-    "StreamK": [0, 1, 2, 3],
+    "StreamK": [0, 1, 2],
+    # Determines if StreamK kernel uses atomics
+    # 0: uses workspace to store partial tiles, accumulate in deterministic fix-up step
+    # 1: uses atomics to accumulate partial tiles
+    "StreamKAtomic": [0, 1],
 
     # 0  : standard launch
     # N>0 : launch persistent kernel with N workgroups per compute unit
@@ -1540,6 +1543,7 @@ defaultBenchmarkCommonParameters = [
     {"MacroTileShapeMin":         [ 1 ] },
     {"MacroTileShapeMax":         [ 64 ] },
     {"StreamK":                   [ 0 ] },
+    {"StreamKAtomic":             [ 0 ] },
     {"PersistentKernel":          [ 0 ] },
     {"PersistentKernelAlongBatch":[ False ] },    # May be default True is better ?
     {"PackBatchDims":             [ 0 ] },

--- a/Tensile/Contractions.py
+++ b/Tensile/Contractions.py
@@ -386,8 +386,8 @@ class ProblemPredicate(Properties.Predicate):
             if ('_GlobalAccumulation' not in state) or (state['_GlobalAccumulation'] != 'MultipleBuffer'):
                 rv += [cls("DeterministicMode", value = False)]
 
-        if ('StreamK' in state) and (state['StreamK'] == 1):
-            # StreamK = 1 uses atomic for partial tiles
+        if ('StreamK' in state) and (state['StreamK'] > 0) and ('StreamKAtomic' in state) and (state['StreamKAtomic'] == 1):
+            # StreamKAtomic = 1 uses atomic for partial tiles
             rv += [cls("DeterministicMode", value = False)]
 
         # debugging: mark this set to allow the problem always runnable with PK
@@ -469,6 +469,7 @@ class SizeMapping:
                  'packBatchDims',
                  'magicDivAlg',
                  'streamK',
+                 'streamKAtomic',
                  'persistentKernel',
                  'persistentKernelAlongBatch',
                  'sourceKernel',
@@ -499,6 +500,7 @@ class SizeMapping:
                    packSummationDims     = d['PackSummationDims'] if 'PackSummationDims' in d else 0,
                    packBatchDims         = d['PackBatchDims'] if 'PackBatchDims' in d else 0,
                    streamK               = d['StreamK'] if 'StreamK' in d else 0,
+                   streamKAtomic         = d['StreamKAtomic'] if 'StreamKAtomic' in d else 0,
                    persistentKernel      = d['PersistentKernel'] if 'PersistentKernel' in d else 0,
                    persistentKernelAlongBatch   = d['PersistentKernelAlongBatch'] if 'PersistentKernelAlongBatch' in d else False,
                    magicDivAlg           = d.get('MagicDivAlg', 1),

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -13444,7 +13444,7 @@ class KernelWriterAssembly(KernelWriter):
       if not self.do["PostLoop"]: return ""
     kStr = ""
     atomic = (kernel["GlobalSplitU"] > 1) and (kernel["_GlobalAccumulation"] != 'MultipleBuffer')
-    atomic = atomic or (kernel["StreamK"] > 0 and kernel["StreamKAtomic"] == 1)
+    atomic = atomic or kernel["StreamKAtomic"] == 1
     useCodeMulAlpha =  kernel["MIArchVgpr"] and applyAlpha and not (kernel["GlobalSplitU"] > 1)
 
     # write possibilities and labels

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -603,8 +603,8 @@ class KernelWriterAssembly(KernelWriter):
       self.defineSgpr("StreamKIterEnd", 1)
       self.defineSgpr("StreamKLocalStart", 1)
       self.defineSgpr("StreamKLocalEnd", 1)
-    if kernel["StreamK"] == 2 or kernel["StreamK"] == 3:
-      self.defineSgpr("SrdWS", 4, 4)
+      if kernel["StreamKAtomic"] == 0:
+        self.defineSgpr("SrdWS", 4, 4)
 
     if kernel["PackSummationDims"] and kernel["GlobalSplitU"]>1:
       self.defineSgpr("GsuNumIter%s"%self.loopChar(kernel,self.unrollIdx), 1)
@@ -882,6 +882,7 @@ class KernelWriterAssembly(KernelWriter):
       kernel["LocalWriteUseSgprB"] = False # Requires DirectToLdsB
 
     # set up useAtomicAdd
+    # TODO Stream-K In future change, either gneeralize GSUAA option, or add toggle to control SK behaviour
     self.useAtomicAdd = kernel["GlobalSplitUAtomicAdd"]
 
     # OptPreLoopVmcnt for PAP:
@@ -1894,7 +1895,7 @@ class KernelWriterAssembly(KernelWriter):
     self.defineSgpr("AddressC", numSgprAddressC, numSgprAddressC, kernarg=True)
     self.defineSgpr("AddressA", numSgprAddressA, numSgprAddressA, preload=True)
     self.defineSgpr("AddressB", numSgprAddressB, numSgprAddressB, preload=True)
-    if kernel["StreamK"] == 2 or kernel["StreamK"] == 3:
+    if kernel["StreamK"] > 0 and kernel["StreamKAtomic"] == 0:
       self.defineSgpr("AddressWS", numSgprAddressWS, kernarg=True)
       self.defineSgpr("AddressFlags", numSgprAddressFlags, kernarg=True)
 
@@ -1975,13 +1976,12 @@ class KernelWriterAssembly(KernelWriter):
       self.defineSgpr("TotalIters", 1, kernarg=True)
       self.defineSgpr("SKItersPerWG", 1, kernarg=True)
       skArgumentToLoad += 9
-      if kernel["StreamK"] == 3: # Two-tile SK
+      if kernel["StreamK"] == 2: # Two-tile SK
         self.defineSgpr("skGrid", 1, kernarg=True)
         self.defineSgpr("skTiles", 1, kernarg=True)
         self.defineSgpr("skExtraIters", 1, kernarg=True)
         # self.defineSgpr("dpTilesPerWG", 1, kernarg=True)
         skArgumentToLoad += 3
-
 
     #------------------------
     # Registers defined below this point are not available in the post-loop
@@ -3764,7 +3764,7 @@ class KernelWriterAssembly(KernelWriter):
       if kernel["StreamK"]:
         # Workload calculations
         kStr += inst("s_mov_b32", sgpr("StreamKIdx"), sgpr("WorkGroup0"), "Save original StreamK index")
-        if kernel["StreamK"] < 3: # Basic SK
+        if kernel["StreamK"] == 1: # Basic SK
           kStr += inst("s_mul_i32", sgpr("StreamKIter"), sgpr("StreamKIdx"), sgpr("SKItersPerWG"), "StreamK starting iteration")
           kStr += inst("s_add_u32", sgpr("StreamKIterEnd"), sgpr("StreamKIter"), sgpr("SKItersPerWG"), "StreamK ending iteration")
           kStr += inst("s_min_u32", sgpr("StreamKIterEnd"), sgpr("StreamKIterEnd"), sgpr("TotalIters"), "Cap ending iter at total iters")
@@ -3772,7 +3772,7 @@ class KernelWriterAssembly(KernelWriter):
           kStr += self.longBranchScc0("label_%04u" % (self.getLabelNum("KernelEnd")), positiveOnly=True)
           # kStr += inst("s_cbranch_scc0", "label_%04u" % (self.getLabelNum("KernelEnd")), "edge case that work doesn't divide well")        
           kStr += self.undefineSgpr("TotalIters")
-        elif kernel["StreamK"] == 3: # Two-tile SK
+        elif kernel["StreamK"] == 2: # Two-tile SK
           # iter count after all extra iters have been distributed
           kStr += inst("s_mul_i32", sgpr("StreamKIter"), sgpr("StreamKIdx"), sgpr("SKItersPerWG"), "StreamK starting iteration (case: after extra iters)")
           kStr += inst("s_add_u32", sgpr("StreamKIter"), sgpr("StreamKIter"), sgpr("skExtraIters"), "Add extra iters")
@@ -3833,7 +3833,7 @@ class KernelWriterAssembly(KernelWriter):
       kStr += inst("s_min_u32", sgpr("StreamKLocalEnd"), sgpr("StreamKIterEnd"), sgpr(stmp+2), "1. (Local) iteration end (SK tile)")
       kStr += inst("s_sub_u32", sgpr("StreamKLocalEnd"), sgpr("StreamKLocalEnd"), sgpr(stmp+1), "2. Local iteration end (SK tile)")
 
-      if kernel["StreamK"] == 3: # Two-tile algorithm
+      if kernel["StreamK"] == 2: # Two-tile algorithm
         # local end (DP tile)
         kStr += inst("s_sub_u32", sgpr(stmp+3), sgpr(stmp+2), sgpr(stmp+1), "Local iteration end (DP tile)")
         # select correct local end
@@ -13444,7 +13444,7 @@ class KernelWriterAssembly(KernelWriter):
       if not self.do["PostLoop"]: return ""
     kStr = ""
     atomic = (kernel["GlobalSplitU"] > 1) and (kernel["_GlobalAccumulation"] != 'MultipleBuffer')
-    atomic = atomic or kernel["StreamK"] == 1
+    atomic = atomic or (kernel["StreamK"] > 0 and kernel["StreamKAtomic"] == 1)
     useCodeMulAlpha =  kernel["MIArchVgpr"] and applyAlpha and not (kernel["GlobalSplitU"] > 1)
 
     # write possibilities and labels
@@ -13529,7 +13529,7 @@ class KernelWriterAssembly(KernelWriter):
     skFixupLabel = self.getNamedLabelUnique("SK_Fixup")
     skStoreLabel = self.getNamedLabelUnique("SK_Store")
 
-    if kernel["StreamK"] == 2 or kernel["StreamK"] == 3:
+    if kernel["StreamK"] > 0 and kernel["StreamKAtomic"] == 0:
       # StreamK store branches
       tmpSgpr = self.sgprPool.checkOut(4, "globalWriteElements", preventOverflow=0)
       # if we did not start the tile, store partials
@@ -13565,7 +13565,7 @@ class KernelWriterAssembly(KernelWriter):
       fixupEdge = [False] # Temporary hack to test no edge variant
       kStr += self.fixupStep(kernel, vectorWidths, elements, fixupEdge, tmpVgpr, tmpCVTVgpr, sCtaIdx, skStoreLabel)
       
-      if kernel["StreamK"] == 3:
+      if kernel["StreamK"] == 2:
         sIterCount = self.sgprPool.checkOut(1, "iterCount", preventOverflow=0)
         kStr += inst("s_add_u32", sgpr(sIterCount), sgpr("SKItersPerWG"), 1, "Add extra iter")
         kStr += inst("s_cmp_lt_u32", sgpr(sCtaIdx), sgpr("skExtraIters"), "Check if next WG had an extra iteration")
@@ -13573,7 +13573,7 @@ class KernelWriterAssembly(KernelWriter):
         kStr += inst("s_add_u32", sgpr(sFixupEnd), sgpr(sFixupEnd), sgpr(sIterCount), "next partial tile iteration")
         self.sgprPool.checkIn(sIterCount)
       kStr += inst("s_add_u32", sgpr(sCtaIdx), sgpr(sCtaIdx), 1, "next partial tile index")
-      if kernel["StreamK"] == 2:
+      if kernel["StreamK"] == 1:
         kStr += inst("s_add_u32", sgpr(sFixupEnd), sgpr(sFixupEnd), sgpr("SKItersPerWG"), "next partial tile iteration")
       kStr += inst("s_cmp_lt_u32", sgpr(sFixupEnd), sgpr("ItersPerTile"), "done loading partial tiles?")
       kStr += inst("s_cbranch_scc1 %s" % skFixupLabel, "Branch to continue fixup loop")
@@ -13601,7 +13601,7 @@ class KernelWriterAssembly(KernelWriter):
         kStr += "%s:%s"%(writeLabels[beta][edge], self.endLine)
         kStr += self.globalWriteProcedure(kernel, vectorWidths, elements, applyAlpha, beta, edge, atomic, tmpVgpr, tmpCVTVgpr, isOptNLL, endLabel)
 
-    if kernel["StreamK"] == 2 or kernel["StreamK"] == 3:
+    if kernel["StreamK"] > 0 and kernel["StreamKAtomic"] == 0:
       kStr += "%s:\n" % (skPartialsLabel)
 
       fixupEdge = [False] # Temporary hack to test no edge variant
@@ -15230,11 +15230,11 @@ class KernelWriterAssembly(KernelWriter):
   def persistentLoopendLongjump(self, kernel):
     kStr = ""
     if kernel["StreamK"]:
-      endIter = "StreamKIterEnd" if kernel["StreamK"] < 3 else "TotalIters"
+      endIter = "StreamKIterEnd" if kernel["StreamK"] == 1 else "TotalIters"
       kStr += inst("s_cmp_ge_u32", sgpr("StreamKIter"), sgpr(endIter), "Check if done all StreamK iterations")
       kStr += self.longBranchScc0(self.getLabelTarget("PersistentLoopStart"), negativeOnly=True)
 
-    if kernel["PersistentKernel"]: # or kernel["StreamK"]:
+    if kernel["PersistentKernel"]:
       # Persistent may generate a SerialWorkGroupIter which is OOB, only loop back if we are in a valid WG:
       stmp = self.getTmpSgpr(1).idx()
       kStr += inst("s_mul_i32", sgpr(stmp), sgpr("NumWorkGroups0"), sgpr("NumWorkGroups1"), "Total WG-0x1")
@@ -16624,7 +16624,7 @@ class KernelWriterAssembly(KernelWriter):
     acc2arch, _ = self.AccToArchMapper(kernel)
 
     complexMultiplier = 2 if kernel["ProblemType"]["DataType"].isComplex() else 1
-    streamK = (kernel["StreamK"] == 2 or kernel["StreamK"] == 3)
+    streamK = (kernel["StreamK"] > 0 and kernel["StreamKAtomic"] == 0)
     self.codeAccVgprRead = Code.Module("AccVgprRead")
     self.codeAccVgprRead.itemList = [None] * kernel["MIRegPerOut"] * complexMultiplier * len(acc2arch)
     if streamK:

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -2989,6 +2989,9 @@ class Solution(collections.abc.Mapping):
           reject(state, "Atomic Stream-K requires BufferStore")
         if state["LocalSplitU"] > 1:
           reject(state, "Atomic Stream-K not working with LocalSplitU")
+    else:
+      # If not using StreamK, set StreamKAtomic to 0 to avoid possibility of duplicate kernels
+      state["StreamKAtomic"] = 0
 
     if state["KernelLanguage"] == "Assembly" and not state["BufferLoad"]:
       # StaggerU only works with source kernels, or with BufferLoad.

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -1791,7 +1791,7 @@ class Solution(collections.abc.Mapping):
   # create StreamKInit Kernels
   def initStreamKInitKernelObjects(self):
     self.streamKInitKernelObjects = []
-    if self["StreamK"] == 2 or self["StreamK"] == 3:
+    if self["StreamK"] > 0 and self["StreamKAtomic"] == 0:
       state = {}
       state["ProblemType"] = deepcopy(self["ProblemType"])
       state["KernelLanguage"] = "Source"
@@ -1803,7 +1803,7 @@ class Solution(collections.abc.Mapping):
   # create BetaOnly Kernels
   def initBetaOnlyKernelObjects(self):
     self.betaOnlyKernelObjects = []
-    if self["GlobalSplitU"] > 1 or self["StreamK"] == 1:
+    if self["GlobalSplitU"] > 1 or self["StreamK"] > 0 and self["StreamKAtomic"] == 1:
       state = {}
       state["ProblemType"] = deepcopy(self["ProblemType"])
       state["KernelLanguage"] = "Source"
@@ -2949,7 +2949,7 @@ class Solution(collections.abc.Mapping):
       state["_GlobalAccumulation"] = None
       state["_WorkspaceSizePerElemC"] = 0
 
-      if state["StreamK"] == 2 or state["StreamK"] == 3:
+      if state["StreamK"] > 0 and state["StreamKAtomic"] == 0:
         # StreamK Workspace size
         computeBytes = state["ProblemType"]["ComputeDataType"].numBytes()
         state["_GlobalAccumulation"] = 'PartialsBuffer'
@@ -2982,7 +2982,7 @@ class Solution(collections.abc.Mapping):
         reject(state, "Cannot enable both Stream-K and PersistentKernel")
       if not state["ProblemType"]["StridedBatched"]:
         reject(state, "General batch not supported with Stream-K")
-      if state["StreamK"] == 1:
+      if state["StreamKAtomic"] == 1:
         if not state["ProblemType"]["DataType"].isSingle():
           reject(state, "Atomic Stream-K currently only tested for SGEMM")
         if not state["BufferStore"]:
@@ -3052,7 +3052,7 @@ class Solution(collections.abc.Mapping):
       print2("in assignDerivedParameters, state['Valid'] = False")
       return
 
-    atomic = ((state["GlobalSplitU"] > 1) and (state["_GlobalAccumulation"] != 'MultipleBuffer')) or state["AtomicAddC"] or state["StreamK"] == 1
+    atomic = ((state["GlobalSplitU"] > 1) and (state["_GlobalAccumulation"] != 'MultipleBuffer')) or state["AtomicAddC"] or (state["StreamK"] > 0 and state["StreamKAtomic"] == 1)
     if atomic and globalParameters["DebugSkipAtomic"]:
       reject(state, "DEBUG: DebugSkipAtomic enabled, rejecting atomic kernel")
     if not atomic and globalParameters["DebugSkipNonAtomic"]:

--- a/Tensile/Source/lib/include/Tensile/ContractionSolution.hpp
+++ b/Tensile/Source/lib/include/Tensile/ContractionSolution.hpp
@@ -82,6 +82,7 @@ namespace Tensile
         int    packSummationDims          = 0;
         int    magicDivAlg                = 1;
         int    streamK                    = 0;
+        int    streamKAtomic              = 0;
         int    persistentKernel           = 0;
         bool   persistentKernelAlongBatch = false;
 

--- a/Tensile/Source/lib/include/Tensile/Serialization/ContractionSolution.hpp
+++ b/Tensile/Source/lib/include/Tensile/Serialization/ContractionSolution.hpp
@@ -91,6 +91,7 @@ namespace Tensile
                 iot::mapOptional(io, "packSummationDims", s.packSummationDims);
                 iot::mapOptional(io, "magicDivAlg", s.magicDivAlg);
                 iot::mapOptional(io, "streamK", s.streamK);
+                iot::mapOptional(io, "streamKAtomic", s.streamKAtomic);
                 iot::mapRequired(io, "persistentKernel", s.persistentKernel);
                 iot::mapRequired(io, "persistentKernelAlongBatch", s.persistentKernelAlongBatch);
                 iot::mapRequired(io, "sourceKernel", s.sourceKernel);

--- a/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -419,7 +419,8 @@ namespace Tensile
             }
         }
 
-        if(sizeMapping.globalAccumulation && (sizeMapping.streamK == 0 || sizeMapping.streamKAtomic == 1))
+        if(sizeMapping.globalAccumulation
+           && (sizeMapping.streamK == 0 || sizeMapping.streamKAtomic == 1))
         {
             rv.args.append<void const*>("ws_d", inputs.ws);
             rv.args.append<void const*>("ws_c", inputs.ws);
@@ -485,7 +486,8 @@ namespace Tensile
                 rv.args.append<typename TypedInputs::BetaType>("beta_2", inputs.beta);
         }
 
-        if(sizeMapping.globalAccumulation && (sizeMapping.streamK == 0 || sizeMapping.streamKAtomic == 1))
+        if(sizeMapping.globalAccumulation
+           && (sizeMapping.streamK == 0 || sizeMapping.streamKAtomic == 1))
         {
             size_t wsStride = startStrideCD ? d.sizes()[0] : 1;
             for(size_t i = startStrideCD; i < d.dimensions(); i++)

--- a/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -419,7 +419,7 @@ namespace Tensile
             }
         }
 
-        if(sizeMapping.globalAccumulation && sizeMapping.streamK < 2)
+        if(sizeMapping.globalAccumulation && (sizeMapping.streamK == 0 || sizeMapping.streamKAtomic == 1))
         {
             rv.args.append<void const*>("ws_d", inputs.ws);
             rv.args.append<void const*>("ws_c", inputs.ws);
@@ -453,7 +453,7 @@ namespace Tensile
             rv.args.append<typename TypedInputs::BType const* const*>("batchB", inputs.batchB);
         }
 
-        if(sizeMapping.streamK >= 2)
+        if(sizeMapping.streamK > 0 && sizeMapping.streamKAtomic == 0)
         {
             // StreamK workspace + flags
             rv.args.append<void const*>("ws", inputs.ws);
@@ -485,7 +485,7 @@ namespace Tensile
                 rv.args.append<typename TypedInputs::BetaType>("beta_2", inputs.beta);
         }
 
-        if(sizeMapping.globalAccumulation && sizeMapping.streamK < 2)
+        if(sizeMapping.globalAccumulation && (sizeMapping.streamK == 0 || sizeMapping.streamKAtomic == 1))
         {
             size_t wsStride = startStrideCD ? d.sizes()[0] : 1;
             for(size_t i = startStrideCD; i < d.dimensions(); i++)
@@ -642,7 +642,6 @@ namespace Tensile
                 rv.args.append<uint32_t>("gridNumWorkGroups0", rv.numWorkGroups.x);
             }
 
-            // if(sizeMapping.persistentKernelAlongBatch || sizeMapping.streamK != 0)
             if(sizeMapping.persistentKernelAlongBatch)
             {
                 uint32_t numGroupTiles0x1 = problemNumGroupTiles0 * problemNumGroupTiles1;
@@ -677,12 +676,12 @@ namespace Tensile
                                          magicShiftProblemNumGroupTiles0By1);
 
                 rv.args.append<uint32_t>("totalIters", totalIters);
-                if(sizeMapping.streamK < 3) // Basic SK
+                if(sizeMapping.streamK == 1) // Basic SK
                 {
                     uint32_t itersPerWave = CeilDivide(totalIters, rv.numWorkGroups.x);
                     rv.args.append<uint32_t>("SKItersPerWG", itersPerWave);
                 }
-                else if(sizeMapping.streamK == 3) // Two-tile SK
+                else if(sizeMapping.streamK == 2) // Two-tile SK
                 {
                     bool bigEnough = tiles > skGrid;
                     // skTiles is number of Stream-K tiles to complete
@@ -1236,7 +1235,7 @@ namespace Tensile
 
         std::vector<KernelInvocation> rv;
 
-        if(sizeMapping.streamK >= 2)
+        if(sizeMapping.streamK > 0 && sizeMapping.streamKAtomic == 0)
         {
             auto   tiles  = problem.getNumTiles(sizeMapping);
             size_t skGrid = getSKGrid(hardware, tiles);
@@ -1253,7 +1252,7 @@ namespace Tensile
             }
         }
 
-        if(sizeMapping.streamK == 1
+        if((sizeMapping.streamK > 0 && sizeMapping.streamKAtomic == 1)
            || (sizeMapping.globalSplitU > 1 && sizeMapping.globalAccumulation != 2))
         {
             if(debug)
@@ -1582,7 +1581,7 @@ namespace Tensile
     {
         size_t size = 0;
 
-        if(sizeMapping.streamK >= 2)
+        if(sizeMapping.streamK > 0 && sizeMapping.streamKAtomic == 0)
         {
             auto   tiles  = problem.getNumTiles(sizeMapping);
             size_t skGrid = getSKGrid(hardware, tiles);
@@ -1953,6 +1952,7 @@ namespace Tensile
                << std::endl
                << std::setw(30) << "magicDivAlg: " << sizeMapping.magicDivAlg << std::endl
                << std::setw(30) << "streamK: " << sizeMapping.streamK << std::endl
+               << std::setw(30) << "streamKAtomic: " << sizeMapping.streamKAtomic << std::endl
                << std::setw(30) << "persistentKernel: " << sizeMapping.persistentKernel << std::endl
                << std::setw(30)
                << "persistentKernelAlongBatch: " << sizeMapping.persistentKernelAlongBatch

--- a/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -419,8 +419,7 @@ namespace Tensile
             }
         }
 
-        if(sizeMapping.globalAccumulation
-           && (sizeMapping.streamK == 0 || sizeMapping.streamKAtomic == 1))
+        if(sizeMapping.globalAccumulation && sizeMapping.streamK == 0)
         {
             rv.args.append<void const*>("ws_d", inputs.ws);
             rv.args.append<void const*>("ws_c", inputs.ws);
@@ -486,8 +485,7 @@ namespace Tensile
                 rv.args.append<typename TypedInputs::BetaType>("beta_2", inputs.beta);
         }
 
-        if(sizeMapping.globalAccumulation
-           && (sizeMapping.streamK == 0 || sizeMapping.streamKAtomic == 1))
+        if(sizeMapping.globalAccumulation && sizeMapping.streamK == 0)
         {
             size_t wsStride = startStrideCD ? d.sizes()[0] : 1;
             for(size_t i = startStrideCD; i < d.dimensions(); i++)

--- a/Tensile/Tests/extended/stream_k/sk_2tile_hgemm_hhs.yaml
+++ b/Tensile/Tests/extended/stream_k/sk_2tile_hgemm_hhs.yaml
@@ -51,7 +51,7 @@ BenchmarkProblems:
         - DepthU: [ 32 ]
         # - DepthU: [ 8, 16, 32, 64 ]
         - VectorWidth: [1]
-        - StreamK: [3]
+        - StreamK: [2]
         - StaggerU: [0, 32]
         - ScheduleIterAlg: [3]
         - SourceSwap: [False, True]

--- a/Tensile/Tests/extended/stream_k/sk_2tile_sgemm.yaml
+++ b/Tensile/Tests/extended/stream_k/sk_2tile_sgemm.yaml
@@ -67,7 +67,8 @@ BenchmarkProblems:
         # - DepthU: [ 2, 4, 8, 16, 32, 64 ]
         # - DepthU: [ 8, 9, 10, 11, 12, 13, 14, 15, 16 ] # depthu 14 failed a test
         - VectorWidth: [1]
-        - StreamK: [3]
+        - StreamK: [2]
+        - StreamKAtomic: [0, 1]
         - StaggerU: [0, 32]
         # - StaggerU: [0]
         - ScheduleIterAlg: [3]
@@ -147,7 +148,8 @@ BenchmarkProblems:
         # - DepthU: [ 2, 4, 8, 16, 32, 64 ]
         # - DepthU: [ 8, 9, 10, 11, 12, 13, 14, 15, 16 ] # depthu 14 failed a test
         - VectorWidth: [1]
-        - StreamK: [3]
+        - StreamK: [2]
+        - StreamKAtomic: [0, 1]
         - StaggerU: [0, 32]
         # - StaggerU: [0]
         - ScheduleIterAlg: [3]

--- a/Tensile/Tests/extended/stream_k/sk_hgemm_hhs.yaml
+++ b/Tensile/Tests/extended/stream_k/sk_hgemm_hhs.yaml
@@ -51,7 +51,7 @@ BenchmarkProblems:
         - DepthU: [ 32 ]
         # - DepthU: [ 8, 16, 32, 64 ]
         - VectorWidth: [1]
-        - StreamK: [2]
+        - StreamK: [1]
         - StaggerU: [0, 32]
         - ScheduleIterAlg: [3]
         - SourceSwap: [False, True]

--- a/Tensile/Tests/extended/stream_k/sk_sgemm.yaml
+++ b/Tensile/Tests/extended/stream_k/sk_sgemm.yaml
@@ -67,7 +67,8 @@ BenchmarkProblems:
         # - DepthU: [ 2, 4, 8, 16, 32, 64 ]
         # - DepthU: [ 8, 9, 10, 11, 12, 13, 14, 15, 16 ] # depthu 14 failed a test
         - VectorWidth: [1]
-        - StreamK: [1, 2]
+        - StreamK: [1]
+        - StreamKAtomic: [0, 1]
         - StaggerU: [0, 32]
         # - StaggerU: [0]
         - ScheduleIterAlg: [3]


### PR DESCRIPTION
Add support for atomic version of 2-tile stream-k algorithm.
This change also cleans up the stream-k tuning parameters. Atomic mode is now a separate parameter.
StreamK=0 is off, regular DP kernel
StreamK=1 is basic stream-k
StreamK=2 is two-tile
StreamKAtomic toggles use of atomics for fixup step (and requirements for flags, workspace, and init kernel)
Atomic mode currently only works for SGEMM. Updated the test suite to use new parameters and include atomic 2-tile tests.