### PR TITLE
Cherry-pick RDNA1 fix into 6.1 release

### DIFF
--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -943,11 +943,19 @@ def generateLogicDataAndSolutions(logicFiles, args):
     # logicData[problemType].append((scheduleName, deviceNames, \
     #     solutionsForSchedule, indexOrder, exactLogic, rangeLogic ))
 
+  (archs, _) = splitArchs()
   if globalParameters["SeparateArchitectures"] or globalParameters["LazyLibraryLoading"]:
     if "fallback" in masterLibraries.keys():
       for key, value in masterLibraries.items():
         if key != "fallback":
           value.insert(deepcopy(masterLibraries["fallback"]))
+      for archName in archs:
+        archName = archName.split('-', 1)[0]
+        if archName not in masterLibraries:
+          print1("Using fallback for arch: " + archName)
+          masterLibraries[archName] = deepcopy(masterLibraries["fallback"])
+          masterLibraries[archName].version = args.version
+
       masterLibraries.pop("fallback")
 
     for _, masterLibrary in masterLibraries.items():


### PR DESCRIPTION
This PR requests to cherry-pick #1897 into ROCm 6.1 release.

#1897 enables RDNA1 (gfx101\*) users to run rocBLAS with the rocblas package from AMD's official repository. Since rocBLAS is almost ubiquitous in ML workflows, this means that all RDNA1 users are essentially unable to run any programs related to ML right now (ROCm/ROCm#2527).

Admittedly, RDNA1 GPUs are [not officially supported](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html#supported-gpus), but this is such a small change that would benefit _all_ users of RDNA1 GPUs, so I believe is very worth it.

This is a NFC for all architectures besides `gfx1010`.

#1897 requires #1888 to function properly, but it seems like #1888 is already cherry-picked into the `release/rocm-rel-6.1` branch in #1905, so cherry-picking #1897 would not break anything.
