### PR TITLE
CMake cleanup to prevent redundant work in client builds

### DIFF
--- a/HostLibraryTests/CMakeLists.txt
+++ b/HostLibraryTests/CMakeLists.txt
@@ -192,10 +192,6 @@ endif()
 
 if(TENSILE_USE_HIP)
 
-    # Make sure the testing libraries get built & copied before the client is built
-    # to avoid segfaults on gtest integration.
-    add_dependencies(TensileTests ${HIP_TEST_LIBRARY_TARGET_DEPS})
-
     target_link_libraries(TensileTests PRIVATE "-Xlinker --whole-archive")
     target_link_libraries(TensileTests PUBLIC ${HIP_TEST_LIBRARIES})
     target_link_libraries(TensileTests PRIVATE "-Xlinker --no-whole-archive")

--- a/HostLibraryTests/hip/CMakeLists.txt
+++ b/HostLibraryTests/hip/CMakeLists.txt
@@ -21,13 +21,12 @@
 # SOFTWARE.
 #
 ################################################################################
-
 set(COMPILER "hipcc")
 set(CODE_OBJECT_VERSION "default")
 
 TensileCreateLibraryFiles(
     "${CMAKE_CURRENT_SOURCE_DIR}/../configs/lite_configs"
-    "${CMAKE_CURRENT_BINARY_DIR}/test_kernels_lite"
+    "${TEST_DATA_DIR}/test_kernels_lite"
     TENSILE_ROOT "${TENSILE_SCRIPT_ROOT}"
     EMBED_LIBRARY test_kernels_lite
     EMBED_KEY     kernels_lite
@@ -38,17 +37,9 @@ TensileCreateLibraryFiles(
     CODE_OBJECT_VERSION ${CODE_OBJECT_VERSION}
     )
 
-# Tests need library and kernels copied to data folder
-TensileCreateCopyTarget(
-    copy_kernels_lite
-    "${LITE_ALL_FILES}"
-    ${TEST_DATA_DIR}/kernels_lite
-    )
-add_dependencies(copy_kernels_lite LITE_LIBRARY_TARGET)
-
 TensileCreateLibraryFiles(
     "${CMAKE_CURRENT_SOURCE_DIR}/../configs/lite_configs_mixed"
-    "${CMAKE_CURRENT_BINARY_DIR}/test_kernels_lite_mixed"
+    "${TEST_DATA_DIR}/test_kernels_lite_mixed"
     TENSILE_ROOT "${TENSILE_SCRIPT_ROOT}"
     EMBED_LIBRARY test_kernels_lite_mixed
     EMBED_KEY     kernels_lite_mixed
@@ -59,17 +50,9 @@ TensileCreateLibraryFiles(
     CODE_OBJECT_VERSION ${CODE_OBJECT_VERSION}
     )
 
-# Tests need library and kernels copied to data folder
-TensileCreateCopyTarget(
-    copy_kernels_lite_mixed
-    "${LITE_MIXED_ALL_FILES}"
-    ${TEST_DATA_DIR}/kernels_lite_mixed
-    )
-add_dependencies(copy_kernels_lite_mixed LITE_MIXED_LIBRARY_TARGET)
-
 TensileCreateLibraryFiles(
     "${CMAKE_CURRENT_SOURCE_DIR}/../configs/lite_configs"
-    "${CMAKE_CURRENT_BINARY_DIR}/test_kernels_lite_2"
+    "${TEST_DATA_DIR}/test_kernels_lite_2"
     TENSILE_ROOT "${TENSILE_SCRIPT_ROOT}"
     EMBED_LIBRARY test_kernels_lite_2
     EMBED_KEY     kernels_lite_2
@@ -80,17 +63,9 @@ TensileCreateLibraryFiles(
     CODE_OBJECT_VERSION ${CODE_OBJECT_VERSION}
     )
 
-# Tests need library and kernels copied to data folder
-TensileCreateCopyTarget(
-    copy_kernels_lite_2
-    "${LITE_2_ALL_FILES}"
-    ${TEST_DATA_DIR}/kernels_lite_2
-    )
-add_dependencies(copy_kernels_lite_2 LITE_2_LIBRARY_TARGET)
-
 TensileCreateLibraryFiles(
     "${CMAKE_CURRENT_SOURCE_DIR}/../configs/tile_aware_selection"
-    "${CMAKE_CURRENT_BINARY_DIR}/test_tile_aware_selection"
+    "${TEST_DATA_DIR}/test_tile_aware_selection"
     TENSILE_ROOT "${TENSILE_SCRIPT_ROOT}"
     EMBED_LIBRARY test_tile_aware_selection
     EMBED_KEY     tile_aware_selection
@@ -100,14 +75,6 @@ TensileCreateLibraryFiles(
     COMPILER_PATH ${CMAKE_CXX_COMPILER}
     CODE_OBJECT_VERSION ${CODE_OBJECT_VERSION}
     )
-
-# Tests need library and kernels copied to data folder
-TensileCreateCopyTarget(
-    copy_kernels_tile_aware_selection
-    "${TILE_AWARE_ALL_FILES}"
-    ${TEST_DATA_DIR}/tile_aware_selection/library
-    )
-add_dependencies(copy_kernels_tile_aware_selection TILE_AWARE_LIBRARY_TARGET)
 
 set(test_yaml rocblas_sgemm_asm_single_kernel.yaml)
 file(COPY ${test_yaml} DESTINATION .)
@@ -127,14 +94,3 @@ set(HIP_TEST_LIBRARIES
     test_kernels_lite_mixed
     test_tile_aware_selection
     TensileClient PARENT_SCOPE)
-
-# Make sure that the TensileTests depends on targets below.
-# Otherwise the TensileTests executable will segfault out.
-set(HIP_TEST_LIBRARY_TARGET_DEPS
-    copy_kernels_lite
-    copy_kernels_lite_mixed
-    copy_kernels_lite_2
-    copy_kernels_tile_aware_selection
-    PARENT_SCOPE
-)
-

--- a/HostLibraryTests/hip/RunGEMMKernelTileSelection_test.cpp
+++ b/HostLibraryTests/hip/RunGEMMKernelTileSelection_test.cpp
@@ -195,11 +195,13 @@ TEST_P(RunGEMMKernelSolutionSelectionTest, KernelsTileSelection)
     // std::cout << problem << std::endl;
 
     auto library = LoadLibraryFile<ContractionProblem>(
-        TestData::Instance().file("kernels_tile_selection/TensileLibrary").native());
+        TestData::Instance().file("test_kernels_tile_selection/library/TensileLibrary").native());
 
     hip::SolutionAdapter adapter(false);
     adapter.loadCodeObjectFile(
-        TestData::Instance().file("kernels_tile_selection/TensileLibrary_gfx906", "co").native());
+        TestData::Instance()
+            .file("test_kernels_tile_selection/library/TensileLibrary_gfx906", "co")
+            .native());
 
     ASSERT_NE(library, nullptr);
 

--- a/HostLibraryTests/testlib/include/RunGEMMKernelTest_impl.hpp
+++ b/HostLibraryTests/testlib/include/RunGEMMKernelTest_impl.hpp
@@ -186,9 +186,9 @@ auto RunGEMMKernelTestParams<DeviceBackend>::TestLibraries_Impl() -> std::vector
 
     {
         auto library = LoadLibraryFile<ContractionProblem, ContractionSolution>(
-            TestData::Instance().file("kernels_lite/TensileLibrary").native());
+            TestData::Instance().file("test_kernels_lite/library/TensileLibrary").native());
         auto adapter = std::make_shared<SolutionAdapter>(debug, "kernels_lite (file)");
-        for(auto file : TestData::Instance().glob("kernels_lite/*.*co"))
+        for(auto file : TestData::Instance().glob("test_kernels_lite/library/*.*co"))
             adapter->loadCodeObjectFile(file.native());
 
         rv.emplace_back(library, adapter, false);
@@ -196,9 +196,9 @@ auto RunGEMMKernelTestParams<DeviceBackend>::TestLibraries_Impl() -> std::vector
 
     {
         auto library = LoadLibraryFile<ContractionProblem, ContractionSolution>(
-            TestData::Instance().file("kernels_lite_mixed/TensileLibrary").native());
+            TestData::Instance().file("test_kernels_lite_mixed/library/TensileLibrary").native());
         auto adapter = std::make_shared<SolutionAdapter>(debug, "kernels_lite_mixed (file)");
-        for(auto file : TestData::Instance().glob("kernels_lite_mixed/*.*co"))
+        for(auto file : TestData::Instance().glob("test_kernels_lite_mixed/library/*.*co"))
             adapter->loadCodeObjectFile(file.native());
 
         rv.emplace_back(library, adapter, true);
@@ -206,13 +206,13 @@ auto RunGEMMKernelTestParams<DeviceBackend>::TestLibraries_Impl() -> std::vector
 
     {
         auto library = LoadLibraryFile<ContractionProblem, ContractionSolution>(
-            TestData::Instance().file("tile_aware_selection/library/TensileLibrary").native());
+            TestData::Instance().file("test_tile_aware_selection/library/TensileLibrary").native());
 
         auto adapter = std::make_shared<SolutionAdapter>(debug, "tile_aware_selection");
-        for(auto file : TestData::Instance().glob("tile_aware_selection/library/*.*co"))
+        for(auto file : TestData::Instance().glob("test_tile_aware_selection/library/*.*co"))
             adapter->loadCodeObjectFile(file.native());
 
-        for(auto file : TestData::Instance().glob("tile_aware_selection/library/*.*hsaco"))
+        for(auto file : TestData::Instance().glob("test_tile_aware_selection/library/*.*hsaco"))
             adapter->loadCodeObjectFile(file.native());
 
         rv.emplace_back(library, adapter, false);

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -232,6 +232,7 @@ globalParameters["SupportedISA"] = [(8,0,3),
 
 globalParameters["CleanupBuildFiles"] = False                     # cleanup build files (e.g. kernel assembly) once no longer needed
 globalParameters["GenerateManifestAndExit"] = False               # Output manifest file with list of expected library objects and exit
+globalParameters["VerifyManifest"] = False                        # Verify manifest file against generated library files and exit.
 globalParameters["ClientBuildPath"] = "0_Build"                   # subdirectory for host code build directory
 globalParameters["BenchmarkProblemsPath"] = "1_BenchmarkProblems" # subdirectory for benchmarking phases
 globalParameters["BenchmarkDataPath"] = "2_BenchmarkData"         # subdirectory for storing final benchmarking data

--- a/Tensile/Parallel.py
+++ b/Tensile/Parallel.py
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# Copyright (C) 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -27,7 +27,6 @@ import os
 import sys
 
 from joblib import Parallel, delayed
-
 
 def CPUThreadCount(enable=True):
   from .Common import globalParameters
@@ -79,13 +78,16 @@ def ParallelMap(function, objects, message="", enable=True, multiArg=True):
   except TypeError: pass
 
   if message != "": message += ": "
-  print("{0}Launching {1} threads{2}...".format(message, threadCount, countMessage))
-  sys.stdout.flush()
+  
+  if globalParameters["PrintLevel"] >= 1:
+    print("{0}Launching {1} threads{2}...".format(message, threadCount, countMessage))
+    sys.stdout.flush()  
   
   pcall = pcallWithGlobalParamsMultiArg if multiArg else pcallWithGlobalParamsSingleArg
   pargs = zip(objects, itertools.repeat(globalParameters))
   rv = Parallel(n_jobs=threadCount)(delayed(pcall)(function, a, params) for a, params in pargs)
+  if globalParameters["PrintLevel"] >= 1:
+    print("{0}Done.".format(message))    
+    sys.stdout.flush()  
   
-  print("{0}Done.".format(message))
-  sys.stdout.flush()
   return rv

--- a/Tensile/cmake/TensileConfig.cmake
+++ b/Tensile/cmake/TensileConfig.cmake
@@ -84,29 +84,6 @@ endif()
 
 add_subdirectory("${Tensile_ROOT}/Source" "Tensile")
 
-# Target is created for copying dependencies
-function(TensileCreateCopyTarget
-    Target_NAME
-    Tensile_OBJECTS_TO_COPY
-    Dest_PATH
-    )
-
-    file(MAKE_DIRECTORY "${Dest_PATH}")
-    add_custom_target(
-        ${Target_NAME} ALL
-        COMMENT "${Target_NAME}: Copying tensile objects to ${Dest_PATH}"
-        DEPENDS ${Tensile_OBJECTS_TO_COPY}
-    )
-    foreach(OBJECT_TO_COPY ${Tensile_OBJECTS_TO_COPY})
-        add_custom_command(
-            TARGET ${Target_NAME} PRE_BUILD
-            COMMAND_EXPAND_LISTS
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different ${OBJECT_TO_COPY} ${Dest_PATH}
-            DEPENDS ${OBJECT_TO_COPY}
-        )
-    endforeach()
-endfunction()
-
 # Output target: ${Tensile_VAR_PREFIX}_LIBRARY_TARGET. Ensures that the libs get built in Tensile_OUTPUT_PATH/library.
 # Output symbol: ${Tensile_VAR_PREFIX}_ALL_FILES. List of full paths of all expected library files in manifest.
 function(TensileCreateLibraryFiles
@@ -196,6 +173,12 @@ function(TensileCreateLibraryFiles
     set(Options ${Options} "--no-library-print-debug")
   endif()
 
+  if(Tensile_VERBOSE)
+    set(Options ${Options} "--verbose=${Tensile_VERBOSE}")
+  else()
+    set(Options ${Options} "--verbose=0")
+  endif()  
+
   if(Tensile_EMBED_LIBRARY)
     set(Options ${Options} "--embed-library=${Tensile_EMBED_LIBRARY}")
   endif()
@@ -266,46 +249,32 @@ function(TensileCreateLibraryFiles
         set(CommandLine env LD_PRELOAD=${ASAN_LIB_PATH} ${CommandLine})
       endif()
 
-      # Create the manifest file of the output libraries.
-      set(Tensile_CREATE_MANIFEST_COMMAND ${CommandLine} "--generate-manifest-and-exit")
-      execute_process(
-        COMMAND ${Tensile_CREATE_MANIFEST_COMMAND}
-        RESULT_VARIABLE Tensile_CREATE_MANIFEST_RESULT
-        COMMAND_ECHO STDOUT)
-
-      if(Tensile_CREATE_MANIFEST_RESULT OR (NOT EXISTS ${Tensile_MANIFEST_FILE_PATH}))
-        message(FATAL_ERROR "Error creating Tensile library: ${Tensile_CREATE_MANIFEST_RESULT}")
-      endif()
-
-      # Defer the actual call of the TensileCreateLibraries to 'make' time as needed.
-      # Read the manifest file and declare the files as expected output.
-      file(STRINGS ${Tensile_MANIFEST_FILE_PATH} Tensile_MANIFEST_CONTENTS)
       add_custom_command(
-        COMMENT "Generating Tensile Libraries"
-        OUTPUT ${Tensile_EMBED_LIBRARY_SOURCE};${Tensile_MANIFEST_CONTENTS}
+        OUTPUT "${Tensile_OUTPUT_PATH}/library"
+        DEPENDS ${Tensile_LOGIC_PATH}
         COMMAND ${CommandLine}
-      )
+        COMMENT "Generating libraries with TensileCreateLibrary")
 
-      set("${Tensile_VAR_PREFIX}_ALL_FILES" ${Tensile_EMBED_LIBRARY_SOURCE};${Tensile_MANIFEST_CONTENTS} PARENT_SCOPE)
-
-      # Create a chained library build target.
-      # We've declared the manifest contents as output of the custom
-      # command above which builds the tensile libs. Now create a
-      # target dependency on those files so that we force the custom
-      # command to be invoked at build time, not cmake time.
-      TensileCreateCopyTarget(
-      "${Tensile_VAR_PREFIX}_LIBRARY_TARGET"
-      "${Tensile_EMBED_LIBRARY_SOURCE};${Tensile_MANIFEST_CONTENTS}"
-      "${Tensile_OUTPUT_PATH}/library"
-    )
-
+      add_custom_target(${Tensile_VAR_PREFIX}_LIBRARY_TARGET
+         DEPENDS "${Tensile_OUTPUT_PATH}/library"
+         COMMAND ${CommandLine} "--verify-manifest"
+         COMMENT "Verifying files in ${Tensile_MANIFEST_FILE_PATH} were generated")
   endif()
 
   if(Tensile_EMBED_LIBRARY)
 
-    add_library(${Tensile_EMBED_LIBRARY} ${Tensile_EMBED_LIBRARY_SOURCE})
-    target_link_libraries(${Tensile_EMBED_LIBRARY} PUBLIC TensileHost)
-
+      set_source_files_properties(${Tensile_EMBED_LIBRARY_SOURCE} PROPERTIES GENERATED TRUE)
+      add_library(${Tensile_EMBED_LIBRARY} ${Tensile_EMBED_LIBRARY_SOURCE})
+      target_link_libraries(${Tensile_EMBED_LIBRARY} PUBLIC TensileHost)
+      
+      add_dependencies(${Tensile_EMBED_LIBRARY} ${Tensile_VAR_PREFIX}_LIBRARY_TARGET)
+    
+      add_custom_command(
+          TARGET ${Tensile_EMBED_LIBRARY} PRE_BUILD
+          COMMAND ${CMAKE_COMMAND} -E copy
+                  ${Tensile_EMBED_LIBRARY_SOURCE}
+                  "${Tensile_OUTPUT_PATH}/library"
+          DEPENDS ${Tensile_EMBED_LIBRARY_SOURCE})
   endif()
 
 endfunction()


### PR DESCRIPTION
The CMake support in Tensile (namely TensileConfig.cmake) is doing unnecessary work. In turn, the configure/build times in downstream projects can take up to 20% longer than is necessary. The unnecessary work is due to:

1. Use of `execute_process` to invoke `TensileCreateLibrary  --generate-manifest-and-exit` which is eagerly run at configuration time regardless if manifest generation is required.
2. Using the contents of TensileManifest.txt as output for a subsequent `add_custom_command` call that is used to generate Tensile build artifacts.

In theory, it is reasonable to use the contents of the manifest as output for a subsequent `add_custom_command` call because this will ensure that the command is not considered satisfied unless all of the files in the manifest are generated. However, CMake needs to know what those files are at configuration time when it is configuring the custom command. Therefore, one must use `execute_process` to generate the manifest which has the consequence of redundantly calling to `TensileCreateLibrary --generate-manifest-and-exit` any time a client reconfigures whether or not it is necessary (and `TensileCreateLibrary --generate-manifest-and-exit` is expensive).

In practice, we would like to invoke `TensileCreateLibrary` once at build time prior to building dependent targets. By relaxing the output requirements of the custom command to just the manifest file. We can eliminate the `execute_process` call altogether. Further, we can provide an analog to checking that the custom command is satisfied (i.e. that it generated all of the expected files) by extending `TensileCreateLibrary` to enforce said check.

This PR includes the necessary changes to avoid the redundant work described above. Further, minor changes to verbosity related logic in `TensileCreateLibrary` were added to ensure users can turn off all output from Tensile.

The current default is set to turn off most of the Tensile output which gives the following output when configuring/building in the client (note the output at 0% which comes from the custom command in TensileConfig):

```
make -j32 install
[  0%] Generating libraries with TensileCreateLibrary
[  0%] Generating /mnt/host/projects/rocBLAS-internal/build/release/include/rocblas/internal/rocblas_device_malloc.hpp
[  1%] Generating prototypes from /mnt/host/projects/rocBLAS-internal/library/src.
[  1%] Built target rocblas_device_malloc
[  1%] Built target rocblas_proto_templates
Tensile::WARNING: Global parameter WriteMasterSolutionIndex = False unrecognized.
[  1%] Verifying files in /mnt/host/projects/rocBLAS-internal/build/release/Tensile/library/TensileManifest.txt were generated
Tensile::WARNING: Global parameter WriteMasterSolutionIndex = False unrecognized.
[  1%] Built target TENSILE_LIBRARY_TARGET
[  1%] Building CXX object Tensile/lib/CMakeFiles/TensileHost.dir/source/ArithmeticUnitTypes.cpp.o
[  1%] Building CXX object Tensile/lib/CMakeFiles/TensileHost.dir/source/AMDGPU.cpp.o
``` 

Users can reconfigure with `-DTensile_VERBOSE=1` or `-DTensile_VERBOSE=2` to get extra tensile output.

Initial testing includes:

- Running: `tox -e lint`
- Running: `tox -v -e py310 -- ./Tensile/Tests -m pre_checkin` 
- Running: `cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=hipcc -DTensile_CPU_THREADS=32 -DTensile_ROOT=$(pwd)/Tensile -S HostLibraryTests -B build; cmake --build build; ./build/TensileTests`

- Integration test with rocBLAS `./install.sh -c -t <path to tensile including these changes>` 
- Running: `./rocblas-test --gtest_filter=*quick*:*pre_checkin*-*known_bug*`