### PR TITLE
Default value for long jump positive and negative

### DIFF
--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -6074,7 +6074,7 @@ class KernelWriterAssembly(KernelWriter):
   # we must use a longer 32 bit version.
   # Use when erroring out "invalid operand due to label > SIMM16"
   ##############################################################################
-  def longBranchPositive(self, label, tmpSgpr):
+  def longBranchPositive(self, label, tmpSgpr=None):
     kStr = ""
     if tmpSgpr is None:
       tmpSgpr = self.getTmpSgpr(3).idx()
@@ -6094,7 +6094,7 @@ class KernelWriterAssembly(KernelWriter):
   # we must use a longer 32 bit version.
   # Use when erroring out "invalid operand due to label > SIMM16"
   ##############################################################################
-  def longBranchNegative(self, label, tmpSgpr):
+  def longBranchNegative(self, label, tmpSgpr=None):
     kStr = ""
     if tmpSgpr is None:
       tmpSgpr = self.getTmpSgpr(3).idx()


### PR DESCRIPTION
I recently changed the long jump function to accept a parameter to optionally reuse temp registers (to reduce peak sgprs). The parameter defaults to None, and then allocates temp registers internally.
The previous change did not set a default "None" for the positive/negative versions, which can cause build errors for some kernel combos. This change sets a default to fix the build.