### PR TITLE
Move from hipcc to amdclang 

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -29,7 +29,7 @@ def runCompileCommand(platform, project, jobName, boolean debug=false)
 {
     project.paths.construct_build_prefix()
 
-    String compiler = 'hipcc'
+    String compiler = '/opt/rocm/bin/amdclang++'
     String pythonVersion = 'py3'
     // Do release build of HostLibraryTests on CI until it is upgraded to rocm 5.3 to
     // avoid bug causing long build times of certain files.
@@ -75,7 +75,7 @@ def runCompileCommand(platform, project, jobName, boolean debug=false)
             pushd build
 
             export PATH=/opt/rocm/bin:\$PATH
-            cmake -DCMAKE_BUILD_TYPE=${buildType} -DCMAKE_CXX_COMPILER=${compiler} -DTensile_CPU_THREADS=${buildThreads} -DTensile_ROOT=\$(pwd)/../Tensile ../HostLibraryTests
+            cmake -DCMAKE_BUILD_TYPE=${buildType} -DCMAKE_CXX_COMPILER=${compiler} -DCMAKE_CXX_FLAGS="-D__HIP_HCC_COMPAT_MODE__=1" -DTensile_CPU_THREADS=${buildThreads} -DTensile_ROOT=\$(pwd)/../Tensile ../HostLibraryTests
             NPROC_BUILD=16
             if [ `nproc` -lt 16 ]
             then
@@ -128,7 +128,7 @@ def runTestCommand (platform, project, jobName, test_marks, boolean skipHostTest
 {
     def test_dir =  "Tensile/Tests"
 
-    String compiler = 'hipcc'
+    String compiler = '/opt/rocm/bin/amdclang++'
     String pythonVersion = 'py3'
     String markSkipHostTest = skipHostTest ? "#" : ""
     String markSkipExtendedTest = !test_marks.contains("extended") ? "\"--gtest_filter=-*Extended*:*Ocl*\"" : "\"--gtest_filter=-*Ocl*\""

--- a/HostLibraryTests/hip/CMakeLists.txt
+++ b/HostLibraryTests/hip/CMakeLists.txt
@@ -21,7 +21,8 @@
 # SOFTWARE.
 #
 ################################################################################
-set(COMPILER "hipcc")
+
+get_filename_component(COMPILER ${CMAKE_CXX_COMPILER} NAME)
 set(CODE_OBJECT_VERSION "default")
 
 TensileCreateLibraryFiles(

--- a/Tensile/ClientExecutable.py
+++ b/Tensile/ClientExecutable.py
@@ -27,7 +27,7 @@ import os
 import subprocess
 
 from . import Common
-from .Common import globalParameters, print2
+from .Common import globalParameters, print2, supportedLinuxCompiler
 from .Parallel import CPUThreadCount
 
 def cmake_path(os_path):
@@ -79,8 +79,8 @@ def clientExecutableEnvironment(builddir=None):
         builddir = os.path.join(globalParameters["OutputPath"], globalParameters["ClientBuildPath"])
     builddir = Common.ensurePath(builddir)
 
-    CxxCompiler = "clang++.exe" if ((os.name == "nt") and (globalParameters['CxxCompiler'] == "hipcc" or globalParameters['CxxCompiler'] == "amdclang++")) else globalParameters['CxxCompiler']
-    CCompiler   = "clang.exe"   if ((os.name == "nt") and (globalParameters['CxxCompiler'] == "hipcc" or globalParameters['CxxCompiler'] == "amdclang")) else globalParameters['CCompiler']
+    CxxCompiler = "clang++.exe" if ((os.name == "nt") and supportedLinuxCompiler(globalParameters['CxxCompiler'])) else globalParameters['CxxCompiler']
+    CCompiler   = "clang.exe"   if ((os.name == "nt") and supportedLinuxCompiler(globalParameters['CxxCompiler'])) else globalParameters['CCompiler']
 
     options = {'CMAKE_BUILD_TYPE': globalParameters["CMakeBuildType"],
                'TENSILE_USE_MSGPACK': 'ON',

--- a/Tensile/ClientExecutable.py
+++ b/Tensile/ClientExecutable.py
@@ -79,8 +79,8 @@ def clientExecutableEnvironment(builddir=None):
         builddir = os.path.join(globalParameters["OutputPath"], globalParameters["ClientBuildPath"])
     builddir = Common.ensurePath(builddir)
 
-    CxxCompiler = "clang++.exe" if ((os.name == "nt") and (globalParameters['CxxCompiler'] == "hipcc")) else globalParameters['CxxCompiler']
-    CCompiler   = "clang.exe"   if ((os.name == "nt") and (globalParameters['CxxCompiler'] == "hipcc")) else globalParameters['CxxCompiler']
+    CxxCompiler = "clang++.exe" if ((os.name == "nt") and (globalParameters['CxxCompiler'] == "hipcc" or globalParameters['CxxCompiler'] == "amdclang++")) else globalParameters['CxxCompiler']
+    CCompiler   = "clang.exe"   if ((os.name == "nt") and (globalParameters['CxxCompiler'] == "hipcc" or globalParameters['CxxCompiler'] == "amdclang")) else globalParameters['CCompiler']
 
     options = {'CMAKE_BUILD_TYPE': globalParameters["CMakeBuildType"],
                'TENSILE_USE_MSGPACK': 'ON',

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -329,6 +329,18 @@ def getArchitectureName(gfxName: str) -> Optional[str]:
         return architectureMap[archKey]
     return None
 
+def supportedLinuxCompiler(compiler: str) -> bool:
+  """ Determines if compiler is supported by Tensile
+      Args:
+          The name of a compiler to test for support.
+      
+      Return:
+          If supported True; otherwise, False.
+  """
+  if (compiler == "hipcc" or compiler == "amdclang++"): return True
+
+  return False
+
 ################################################################################
 # Enumerate Valid Solution Parameters
 ################################################################################
@@ -2252,7 +2264,7 @@ def printCapTable(parameters):
 def which(p):
     exes = [p+x for x in ['', '.exe', '.bat']]
     system_path = os.environ['PATH'].split(os.pathsep)
-    if (p == 'hipcc' or p == 'amdclang++') and 'CMAKE_CXX_COMPILER' in os.environ and os.path.isfile(os.environ['CMAKE_CXX_COMPILER']):
+    if supportedLinuxCompiler(p) and 'CMAKE_CXX_COMPILER' in os.environ and os.path.isfile(os.environ['CMAKE_CXX_COMPILER']):
         return os.environ['CMAKE_CXX_COMPILER']
     for dirname in system_path+[globalParameters["ROCmBinPath"]]:
         for exe in exes:
@@ -2319,7 +2331,7 @@ def assignGlobalParameters( config ):
 
   if "TENSILE_ROCM_ASSEMBLER_PATH" in os.environ:
     globalParameters["AssemblerPath"] = os.environ.get("TENSILE_ROCM_ASSEMBLER_PATH")
-  elif globalParameters["AssemblerPath"] is None and (globalParameters["CxxCompiler"] == "hipcc" or globalParameters["CxxCompiler"] == "amdclang++"):
+  elif globalParameters["AssemblerPath"] is None and supportedLinuxCompiler(globalParameters["CxxCompiler"]):
     if os.name == "nt":
       globalParameters["AssemblerPath"] = locateExe(globalParameters["ROCmBinPath"], "clang++.exe")
     else:

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -247,7 +247,7 @@ globalParameters["DictLibraryLogic"] = False
 globalParameters["CurrentISA"] = (0,0,0)
 globalParameters["ROCmAgentEnumeratorPath"] = None      # /opt/rocm/bin/rocm_agent_enumerator
 globalParameters["ROCmSMIPath"] = None                  # /opt/rocm/bin/rocm-smi
-globalParameters["AssemblerPath"] = None                # /opt/rocm/hip/bin/hipcc
+globalParameters["AssemblerPath"] = None                # /opt/rocm/llvm/bin/clang++
 globalParameters["WorkingPath"] = os.getcwd()           # path where tensile called from
 globalParameters["IndexChars"] =  "IJKLMNOPQRSTUVWXYZ"  # which characters to use for C[ij]=Sum[k] A[ik]*B[jk]
 globalParameters["ScriptPath"] = os.path.dirname(os.path.realpath(__file__))            # path to Tensile/Tensile.py
@@ -261,7 +261,8 @@ else:
   globalParameters["RuntimeLanguage"] = "HIP"
 
 globalParameters["CodeObjectVersion"] = "default"
-globalParameters["CxxCompiler"] = "hipcc"
+globalParameters["CxxCompiler"] = "amdclang++"
+globalParameters["CCompiler"] = "amdclang"
 globalParameters["Architecture"] = "all"
 
 # might be deprecated
@@ -2251,7 +2252,7 @@ def printCapTable(parameters):
 def which(p):
     exes = [p+x for x in ['', '.exe', '.bat']]
     system_path = os.environ['PATH'].split(os.pathsep)
-    if p == 'hipcc' and 'CMAKE_CXX_COMPILER' in os.environ and os.path.isfile(os.environ['CMAKE_CXX_COMPILER']):
+    if (p == 'hipcc' or p == 'amdclang++') and 'CMAKE_CXX_COMPILER' in os.environ and os.path.isfile(os.environ['CMAKE_CXX_COMPILER']):
         return os.environ['CMAKE_CXX_COMPILER']
     for dirname in system_path+[globalParameters["ROCmBinPath"]]:
         for exe in exes:
@@ -2300,6 +2301,8 @@ def assignGlobalParameters( config ):
   globalParameters["CmakeCxxCompiler"] = None
   if "CMAKE_CXX_COMPILER" in os.environ:
     globalParameters["CmakeCxxCompiler"] = os.environ.get("CMAKE_CXX_COMPILER")
+  if "CC" in os.environ:
+    globalParameters["CmakeCCompiler"] = os.environ.get("CC")    
 
   globalParameters["ROCmBinPath"] = os.path.join(globalParameters["ROCmPath"], "bin")
 
@@ -2311,14 +2314,18 @@ def assignGlobalParameters( config ):
 
   if "CxxCompiler" in config:
     globalParameters["CxxCompiler"] = config["CxxCompiler"]
+  if "CCompiler" in config:
+    globalParameters["CCompiler"] = config["CCompiler"]    
 
   if "TENSILE_ROCM_ASSEMBLER_PATH" in os.environ:
     globalParameters["AssemblerPath"] = os.environ.get("TENSILE_ROCM_ASSEMBLER_PATH")
-  elif globalParameters["AssemblerPath"] is None and globalParameters["CxxCompiler"] == "hipcc":
+  elif globalParameters["AssemblerPath"] is None and (globalParameters["CxxCompiler"] == "hipcc" or globalParameters["CxxCompiler"] == "amdclang++"):
     if os.name == "nt":
       globalParameters["AssemblerPath"] = locateExe(globalParameters["ROCmBinPath"], "clang++.exe")
     else:
-      globalParameters["AssemblerPath"] = locateExe(os.path.join(globalParameters["ROCmPath"], "llvm/bin"), "clang++")
+      bin_path = "llvm/bin" if globalParameters["CxxCompiler"] == "hipcc" else "bin"
+      compiler = "clang++" if globalParameters["CxxCompiler"] == "hipcc" else "amdclang++"
+      globalParameters["AssemblerPath"] = locateExe(os.path.join(globalParameters["ROCmPath"], bin_path), compiler)
 
   globalParameters["ROCmSMIPath"] = locateExe(globalParameters["ROCmBinPath"], "rocm-smi")
 
@@ -2355,6 +2362,8 @@ def assignGlobalParameters( config ):
   # Due to platform.linux_distribution() being deprecated, just try to run dpkg regardless.
   # The alternative would be to install the `distro` package.
   # See https://docs.python.org/3.7/library/platform.html#platform.linux_distribution
+  
+  # This may not be sufficient for amdclang
   try:
     if os.name == "nt":
       compileArgs = ['perl'] + [which('hipcc')] + ['--version']

--- a/Tensile/GenerateSummations.py
+++ b/Tensile/GenerateSummations.py
@@ -62,7 +62,7 @@ def createLibraryForBenchmark(logicPath, libraryPath, currentPath):
     pythonExePath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "bin", "TensileCreateLibrary")
     args = [pythonExePath, \
         "--merge-files", "--new-client-only", "--no-short-file-names", "--no-library-print-debug", \
-        "--architecture=all", "--cxx-compiler=hipcc", "--library-format=yaml", \
+        "--architecture=all", "--cxx-compiler="+globalParameters["CxxCompiler"], "--library-format=yaml", \
         logicPath, libraryPath, "HIP"]
 
     try:

--- a/Tensile/KernelWriterSource.py
+++ b/Tensile/KernelWriterSource.py
@@ -466,7 +466,7 @@ class KernelWriterSource(KernelWriter):
         kStr += "  } while (assumed != old);%s" % (self.endLine)
         kStr += "}%s" % (self.endLine)
         """
-        if globalParameters["CxxCompiler"] == "hipcc":
+        if globalParameters["CxxCompiler"] == "hipcc" or globalParameters["CxxCompiler"] == "amdclang++":
           kStr += self.endLine
           kStr += "__device__ inline int atomicAddType(int *fPtr, int operand)%s" % (self.endLine)
           kStr += "{%s" % (self.endLine)

--- a/Tensile/Source/CMakeLists.txt
+++ b/Tensile/Source/CMakeLists.txt
@@ -40,7 +40,7 @@ set(TENSILE_USE_OPENMP   ON CACHE BOOL "Use OpenMP to improve performance.")
 set(TENSILE_STATIC_ONLY  ON CACHE BOOL "Disable exposing Tensile symbols in a shared library.")
 
 if(NOT DEFINED CXX_VERSION_STRING)
-    if(CMAKE_CXX_COMPILER MATCHES ".*/hipcc$")
+if(CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" OR CMAKE_CXX_COMPILER MATCHES ".*clang\\+\\+")
       # Determine if CXX Compiler is hip-clang or nvcc
       execute_process(COMMAND ${CMAKE_CXX_COMPILER} "--version" OUTPUT_VARIABLE CXX_OUTPUT
               OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/Tensile/Source/lib/source/hip/CMakeLists.txt
+++ b/Tensile/Source/lib/source/hip/CMakeLists.txt
@@ -22,8 +22,6 @@
 #
 ################################################################################
 
-set(CMAKE_CXX_COMPILER ${HIP_HIPCC_EXECUTABLE})
-
 add_library(TensileHip STATIC
             HipSolutionAdapter.cpp
             HipHardware.cpp)

--- a/Tensile/Source/lib/source/ocl/CMakeLists.txt
+++ b/Tensile/Source/lib/source/ocl/CMakeLists.txt
@@ -22,8 +22,6 @@
 #
 ################################################################################
 
-set(CMAKE_CXX_COMPILER ${HIP_HIPCC_EXECUTABLE})
-
 add_library(TensileOcl STATIC
             OclHardware.cpp
             OclSolutionAdapter.cpp

--- a/Tensile/Tensile.py
+++ b/Tensile/Tensile.py
@@ -122,8 +122,8 @@ def addCommonArguments(argParser):
         help="use serial kernel and solution names")
     argParser.add_argument("--no-merge-files", dest="noMergeFiles", action="store_true", \
         help="kernels and solutions written to individual files")
-    argParser.add_argument("--cxx-compiler", dest="CxxCompiler", choices=["hipcc"], \
-        action="store", default="hipcc", help="select which compiler to use")
+    argParser.add_argument("--cxx-compiler", dest="CxxCompiler", choices=["hipcc", 'amdclang++'], \
+        action="store", default="amdclang++", help="select which compiler to use")
     argParser.add_argument("--library-format", dest="LibraryFormat", choices=["yaml", "msgpack"], \
         action="store", help="select which library format to use")
     argParser.add_argument("--client-build-path", default=None)

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -154,12 +154,14 @@ def getAssemblyCodeObjectFiles(kernels, kernelWriterAssembly, outputPath):
     return coFiles
 
 def which(p):
+    """Need to add documentation and likely testing
+    """
     if os.name == "nt":
         exes = [p+x for x in ['.bat', '', '.exe']]  # bat may be front end for file with no extension
     else:
         exes = [p+x for x in ['', '.exe', '.bat']]
     system_path = os.environ['PATH'].split(os.pathsep)
-    if p == 'hipcc' and 'CMAKE_CXX_COMPILER' in os.environ and os.path.isfile(os.environ['CMAKE_CXX_COMPILER']):
+    if (p == 'hipcc' or p == 'amdclang++') and 'CMAKE_CXX_COMPILER' in os.environ and os.path.isfile(os.environ['CMAKE_CXX_COMPILER']):
         return os.environ['CMAKE_CXX_COMPILER']
     for dirname in system_path+[globalParameters["ROCmBinPath"]]:
         for exe in exes:
@@ -212,13 +214,15 @@ def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile):
 
     coFilenames = []
 
-    if (CxxCompiler == "hipcc"):
+    if (CxxCompiler == "hipcc" or CxxCompiler == "amdclang++"):
       archs, cmdlineArchs = splitArchs()
 
       archFlags = ['--offload-arch=' + arch for arch in cmdlineArchs]
-
-      hipFlags = ["--genco", "-D__HIP_HCC_COMPAT_MODE__=1"] #needs to be fixed when Maneesh's change is made available
-
+      
+      hipFlags = ["-D__HIP_HCC_COMPAT_MODE__=1"] #needs to be fixed when Maneesh's change is made available
+      hipFlags += ["--genco"] if CxxCompiler == "hipcc" else ["--cuda-device-only", "-x", "hip", "-O3"] 
+      if CxxCompiler == "amdclang++": 
+        hipFlags += ["-mllvm", "-amdgpu-early-inline-all=true", "-mllvm", "-amdgpu-function-calls=false"] 
       hipFlags += ['-I', outputPath]
 
       # Add build-id for builds with rocm 5.3+
@@ -231,12 +235,12 @@ def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile):
 
       if os.name == "nt":
         hipFlags += ['-std=c++14', '-fms-extensions', '-fms-compatibility', '-fPIC', '-Wno-deprecated-declarations']
-        compileArgs = launcher + [which('hipcc')] + hipFlags + archFlags + [kernelFile, '-c', '-o', os.path.join(buildPath, objectFilename)]
+        compileArgs = launcher + [which(CxxCompiler)] + hipFlags + archFlags + [kernelFile, '-c', '-o', os.path.join(buildPath, objectFilename)]
       else:
-        compileArgs = launcher + [which('hipcc')] + hipFlags + archFlags + [kernelFile, '-c', '-o', os.path.join(buildPath, objectFilename)]
+        compileArgs = launcher + [which(CxxCompiler)] + hipFlags + archFlags + [kernelFile, '-c', '-o', os.path.join(buildPath, objectFilename)]
 
       if globalParameters["PrintCodeCommands"]:
-        print('hipcc:', ' '.join(compileArgs))
+        print1(CxxCompiler + ':' + ' '.join(compileArgs))
       # change to use  check_output to force windows cmd block util command finish
       try:
         out = subprocess.check_output(compileArgs, stderr=subprocess.STDOUT)
@@ -246,9 +250,11 @@ def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile):
         raise
 
       # get hipcc version due to compatiblity reasons
+      # If we aren't using hipcc what happens?
       hipccver = globalParameters['HipClangVersion'].split(".")
       hipccMaj = int(hipccver[0])
       hipccMin = int(hipccver[1])
+
       # for hipclang 5.2 and above, clang offload bundler changes the way input/output files are specified
       inflag = "-inputs"
       outflag = "-outputs"
@@ -286,13 +292,13 @@ def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile):
               bundlerArgs = [bundler, "-type=o", "-targets=%s" % target,
                            "%s=%s" % (inflag, infile), "%s=%s" % (outflag, outfile), "-unbundle"]
               if globalParameters["PrintCodeCommands"]:
-                print(' '.join(bundlerArgs))
+                print1(' '.join(bundlerArgs))
               # change to use  check_output to force windows cmd block util command finish
               out = subprocess.check_output(bundlerArgs, stderr=subprocess.STDOUT)
               print2(out)
 
       except subprocess.CalledProcessError as err:
-        print(err.output)
+        print1(err.output)
         for i in range(len(archs)):
           outfile = os.path.join(buildPath, "{0}-000-{1}.hsaco".format(soFilename, archs[i]))
           coFilenames.append(os.path.split(outfile)[1])
@@ -300,13 +306,13 @@ def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile):
           bundlerArgs = [bundler, "-type=o", "-targets=hip-amdgcn-amd-amdhsa--%s" % cmdlineArchs[i],
                          "%s=%s" % (inflag, infile), "%s=%s" % (outflag, outfile), "-unbundle"]
           if globalParameters["PrintCodeCommands"]:
-            print(' '.join(bundlerArgs))
+            print1(' '.join(bundlerArgs))
           # change to use  check_output to force windows cmd block util command finish
           try:
             out = subprocess.check_output(bundlerArgs, stderr=subprocess.STDOUT)
             print2(out)
           except subprocess.CalledProcessError as err:
-            print(err.output)
+            print1(err.output)
             raise
     else:
       raise RuntimeError("Unknown compiler {}".format(CxxCompiler))
@@ -320,8 +326,8 @@ def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile):
         destCOs = [os.path.join(destDir, arch, name) for name in archCoFilenames]
         destCosList += destCOs
         if globalParameters["PrintCodeCommands"]:
-          print ("# copy source code objects    : ", extractedCOs)
-          print ("# to dest source code objects : ", destCOs)
+          print1("# copy source code objects    : ", extractedCOs)
+          print1("# to dest source code objects : ", destCOs)
         for (src, dst) in zip(extractedCOs, destCOs):
           shutil.copyfile(src, dst)
     else:
@@ -690,7 +696,7 @@ def buildObjectFileNames(kernelWriterSource, kernelWriterAssembly, solutions, ke
   cxxCompiler = globalParameters["CxxCompiler"]
 
   # Source based kernels are built for all supported architectures
-  if (cxxCompiler == 'hipcc'):
+  if (cxxCompiler == 'hipcc' or cxxCompiler == 'amdclang++'):
     sourceArchs, _ = splitArchs()
   else:
     raise RuntimeError("Unknown compiler %s" % cxxCompiler)
@@ -731,12 +737,12 @@ def buildObjectFileNames(kernelWriterSource, kernelWriterAssembly, solutions, ke
     allSources = sourceKernelNames + kernelHelperObjNames
 
     for kernelName in (allSources):
-      if (cxxCompiler == 'hipcc'):
+      if (cxxCompiler == 'hipcc' or cxxCompiler == 'amdclang++'):
         sourceLibFiles += ["%s.so-000-%s.hsaco" % (kernelName, arch) for arch in sourceArchs]
       else:
         raise RuntimeError("Unknown compiler {}".format(cxxCompiler))
   elif globalParameters["NumMergedFiles"] > 1:
-    if (cxxCompiler == 'hipcc'):
+    if (cxxCompiler == 'hipcc' or cxxCompiler == 'amdclang++'):
       for kernelIndex in range(0, globalParameters["NumMergedFiles"]):
         sourceLibFiles += ["Kernels%d.so-000-%s.hsaco" % (kernelIndex, arch) for arch in sourceArchs]
     else:
@@ -744,10 +750,10 @@ def buildObjectFileNames(kernelWriterSource, kernelWriterAssembly, solutions, ke
   elif globalParameters["LazyLibraryLoading"]:
     fallbackLibs = list(set([kernel._state["codeObjectFile"] for kernel in kernels if "fallback" in kernel._state.get('codeObjectFile', "")]))
     sourceLibFiles += ["{0}_{1}.hsaco".format(name, arch) for name, arch in itertools.product(fallbackLibs, sourceArchs)]
-    if (cxxCompiler == 'hipcc'):
+    if (cxxCompiler == 'hipcc' or cxxCompiler == 'amdclang++'):
       sourceLibFiles += ["Kernels.so-000-%s.hsaco" % (arch) for arch in sourceArchs]
   else: # Merge
-    if (cxxCompiler == 'hipcc'):
+    if (cxxCompiler == 'hipcc' or cxxCompiler == 'amdclang++'):
       sourceLibFiles += ["Kernels.so-000-%s.hsaco" % (arch) for arch in sourceArchs]
     else:
       raise RuntimeError("Unknown compiler {}".format(cxxCompiler))
@@ -1088,7 +1094,7 @@ def TensileCreateLibrary():
   argParser.add_argument("LogicPath",       help="Path to LibraryLogic.yaml files.")
   argParser.add_argument("OutputPath",      help="Where to write library files?")
   argParser.add_argument("RuntimeLanguage", help="Which runtime language?", choices=["OCL", "HIP", "HSA"])
-  argParser.add_argument("--cxx-compiler",           dest="CxxCompiler",       choices=["hipcc"],       action="store", default="hipcc")
+  argParser.add_argument("--cxx-compiler",           dest="CxxCompiler",       choices=["hipcc", 'amdclang++'],       action="store", default="amdclang++")
   argParser.add_argument("--cmake-cxx-compiler",     dest="CmakeCxxCompiler",  action="store")
   argParser.add_argument("--code-object-version",    dest="CodeObjectVersion", choices=["default", "V4", "V5"], action="store")
   argParser.add_argument("--architecture",           dest="Architecture",      type=str, action="store", default="all", 
@@ -1294,8 +1300,8 @@ def TensileCreateLibrary():
   sanityCheck1 = setB - setA
 
   if globalParameters["PrintCodeCommands"]:
-    print("codeObjectFiles:", codeObjectFiles)
-    print("sourceLibPaths + asmLibPaths:", sourceLibPaths + asmLibPaths)
+    print1("codeObjectFiles:", codeObjectFiles)
+    print1("sourceLibPaths + asmLibPaths:", sourceLibPaths + asmLibPaths)
 
   assert len(sanityCheck0) == 0, "Unexpected code object files: {}".format(sanityCheck0)
   if not globalParameters["GenerateSourcesAndExit"]:

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -221,8 +221,8 @@ def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile):
       
       hipFlags = ["-D__HIP_HCC_COMPAT_MODE__=1"] #needs to be fixed when Maneesh's change is made available
       hipFlags += ["--genco"] if CxxCompiler == "hipcc" else ["--cuda-device-only", "-x", "hip", "-O3"] 
-      if CxxCompiler == "amdclang++": 
-        hipFlags += ["-mllvm", "-amdgpu-early-inline-all=true", "-mllvm", "-amdgpu-function-calls=false"] 
+      #if CxxCompiler == "amdclang++": 
+        #hipFlags += ["-mllvm", "-amdgpu-early-inline-all=true", "-mllvm", "-amdgpu-function-calls=false"] 
       hipFlags += ['-I', outputPath]
 
       # Add build-id for builds with rocm 5.3+

--- a/Tensile/Tests/hipModuleLoad_timing/Makefile
+++ b/Tensile/Tests/hipModuleLoad_timing/Makefile
@@ -22,7 +22,7 @@
 #
 ################################################################################
 
-CXX=/opt/rocm/hip/bin/hipcc
+CXX?=/opt/rocm/hip/bin/amdclang++
 LIBFLAGS=-L/opt/rocm/hip/lib/
 LIBS=-lamdhip64
 INCFLAGS=-I/opt/rocm/hip/include/

--- a/Tensile/Tests/unit/test_TensileCreateLibrary.py
+++ b/Tensile/Tests/unit/test_TensileCreateLibrary.py
@@ -73,7 +73,7 @@ def test_WriteClientLibraryFromSolutions(tmpdir):
     Common.globalParameters["MergeFiles"] = True
     Common.globalParameters["CodeObjectVersion"] = "default"
     Common.globalParameters["YAML"] = True
-    Common.globalParameters["CxxCompiler"] = "hipcc"
+    Common.globalParameters["CxxCompiler"] = "amdclang++"
     Common.assignGlobalParameters({})
 
     libraryWorkingPath = tmpdir.mkdir("lib")


### PR DESCRIPTION
The goal of this change set is to move the default compiler from hipcc to amdclang++. The most significant difference between hipcc and amdclang are the flags used when invoking the compiler wrapped by hipcc. We attempt to delineate those differences below by noting if a flag is defaulted (d), set manually (m) or unset (blank):

 | Flag                                                        | hipcc    | amdclang | Notes |
| ------------------------------------------- | -------- |------------|-----------------------------------------|
| `-O3`                                                        | d | m | amdclang is `O2` by default                  |
| `-x hip`                                                     | d | m | Failure to compile if unset                     |
| `-D__HIP_HCC_COMPAT_MODE__=1`      | d | m | DecisionTree test segfaults when unset | 
| `-mrelax-all`                                             | d |      |    |
| `-mframe-pointer=all`                             | d |      |    |
| `-mframe-pointer=none`                        |    | d |    |
| `-Wno-format-nonliteral`                        | d |     |    | 
| `-fallow-half-arguments-and-returns`     | d |     |    |
| `-mllvm -amdgpu-early-inline-all=true`  | d |     |    |   
| `-mllvm -amdgpu-function-calls=false`   | d |     |    |
| `--genco` | m |     |    |
| `--cuda-device-only` | d | m |  This is set for hipcc when `genco` is passed  |

To reproduce one can do the following:

**Configure the HostTestLibrary directory**

```
# hipcc
cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=hipcc -DTensile_CPU_THREADS=32 -DTensile_ROOT=`pwd`/Tensile -S HostLibraryTests -B build

# amdclang++
cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=/opt/rocm/bin/amdclang++ -DTensile_CPU_THREADS=32 -DTensile_ROOT=`pwd`/Tensile -S HostLibraryTests -B build/host3 -DCMAKE_CXX_FLAGS="-D__HIP_HCC_COMPAT_MODE__=1"
```

**Run the build**

```
cmake --build build/host -j 32
```

**Remove DecisionTree test binaries, rebuild with verbosity and review the history for build command**

```
rm build/host/CMakeFiles/TensileTest.dir/DecisionTree_test.cpp.o
cmake --build build/host --verbose
```

**Run the build command from above with `-v`**

```
cd build/host
/opt/rocm/bin/amdclang++ -v <args...> CMakeFiles/TensileTests.dir/DecisionTree_test.cpp.o -MF CMakeFiles/TensileTests.dir/DecisionTree_test.cpp.o.d -o CMakeFiles/TensileTests.dir/DecisionTree_test.cpp.o -c /mnt/host/projects/tensile-wts/clang-migration/HostLibraryTests/DecisionTree_test.cpp
```
The command above will output the detailed compilation commands and arguments used to determine differences in compilation with hipcc and amdclang++.