### PR TITLE
Update verifyManifest function

### DIFF
--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -53,6 +53,10 @@ import sys
 import time
 
 from copy import deepcopy
+from pathlib import Path
+
+TENSILE_MANIFEST_FILENAME = "TensileManifest.txt"
+TENSILE_LIBRARY_DIR = "library"
 
 ################################################################################
 def processKernelSource(kernel, kernelWriterSource, kernelWriterAssembly):
@@ -1047,19 +1051,20 @@ def writeMasterSolutionIndexCSV(outputPath, masterLibraries):
     print1("Error writing MasterSolutionIndex %s" % err)
 
 
-def verifyManifest(manifest) -> bool:
-  """Returns a bool indicating if the files listed in the manifest exist on disk.
+def verifyManifest(manifest: Path) -> bool:
+  """Verifies whether the files listed in the manifest exist on disk.
   
   Args:
-      manifest (str): path to the manifest file
+      manifest: Path to the manifest file.
   
   Returns:
-      list: a list of strings representing the header columns
+      True if all files exist on disk, otherwise False.
   """
-  with open(manifest, "r") as generatedFiles:
-    files = [filename for filename in generatedFiles.readlines() if not os.path.exists(filename.rstrip())]
-  
-  return False if len(files) > 0  else True
+  with open(manifest, mode="r") as generatedFiles:
+    for f in generatedFiles.readlines():
+      if not Path(f.rstrip()).exists():
+        return False
+  return True
 
 ################################################################################
 # Tensile Create Library
@@ -1185,9 +1190,8 @@ def TensileCreateLibrary():
 
   assignGlobalParameters(arguments)
 
-  libraryPath = os.path.join(outputPath, "library")
-  ensurePath(libraryPath)
-  manifestFile = os.path.join(libraryPath, "TensileManifest.txt")
+  manifestFile = Path(outputPath)/TENSILE_LIBRARY_DIR/TENSILE_MANIFEST_FILENAME
+  manifestFile.parent.mkdir(exist_ok=True)
 
   if globalParameters["VerifyManifest"]: 
     if verifyManifest(manifestFile):

--- a/docs/src/api-reference/TensileCreateLibrary.rst
+++ b/docs/src/api-reference/TensileCreateLibrary.rst
@@ -5,4 +5,4 @@
 TensileCreateLibrary
 ====================
 
-<this file is currently empty>
+.. autofunction:: Tensile.TensileCreateLibrary::verifyManifest


### PR DESCRIPTION
**Objectives:**
- Minor doc-string and type-hint updates to `verifyManifest` in TensileCreateLibrary.
- Update unit testing.
- Integrate the inline documentation into the documentation pipeline.

**Outcomes:**
- Automate API documentation and unit tests for `verifyManifest`

**Testing:**

Unit testing:
- Minor updates to existing unit tests

Command to run unit tests (from Tensile/Tensile/Tests):
```
$ pytest unit/test_TensileCreateLibrary.py
```

Integration testing:
- Build rocBLAS via ./install.sh -c for both the source and destination branches (see Docker environment info below)
Compare generated Tensile manifests (build/release/Tensile/library/TensileManifest.txt) with diff; no changes.

**Notable changes:**
- Use `pathlib.Path` for path-based operations instead of `os`

**Docker environment info:**

```
$ cat /etc/os-release | head -1
PRETTY_NAME="Ubuntu 22.04.3 LTS"
```
```
$ apt show rocm-libs -a | head -2 | tail +2
Version: 6.1.2.60102-119~22.04
```
```
$ uname -r
5.15.0-86-generic
```