### PR TITLE
Refactor logic file discovery

### DIFF
--- a/Tensile/Tests/unit/test_TensileCreateLibrary.py
+++ b/Tensile/Tests/unit/test_TensileCreateLibrary.py
@@ -33,6 +33,8 @@ import Tensile.ClientWriter as ClientWriter
 import Tensile.SolutionStructs as SolutionStructs
 import yaml
 import contextlib
+import uuid
+import shutil
 
 from pathlib import Path
 
@@ -191,3 +193,106 @@ def test_verifyManifest():
             generatedFile.write("%s\n" %(filePath) )
 
     assert not TensileCreateLibrary.verifyManifest(manifestFile), "files in manifest are on disk, but shouldn't be"
+
+def test_findLogicFiles():
+
+    def setup():
+        baseDir = Path("no-commit-test-logic-files")
+
+        # Start with clean state
+        with contextlib.suppress(FileNotFoundError):
+            shutil.rmtree(baseDir)
+        baseDir.mkdir()
+
+        lazyLoading = False
+        experimentalDir = "/experimental/"
+        return baseDir, lazyLoading, experimentalDir
+
+    def outputMatchesOldLogic1():
+        baseDir, lazyLoading, experimentalDir = setup()
+        logicArchs = set(Common.architectureMap.values())
+        logicArchs.add("hip")
+        logicArchs.remove("_")  # Remove the value `_` associated with key `all`
+
+        for d in logicArchs:
+            createDirectoryWithYamls(baseDir / d, "foo", "yaml")
+
+        result = TensileCreateLibrary.findLogicFiles(baseDir, logicArchs, lazyLoading, experimentalDir)
+        expected = findLogicFiles_oldLogic(baseDir, logicArchs, lazyLoading, experimentalDir)
+        return result == expected
+
+    def outputMatchesOldLogic2():
+        baseDir, lazyLoading, experimentalDir = setup()
+        logicArchs = set(Common.architectureMap.values())
+        logicArchs.add("hip")
+        logicArchs.remove("_")  # Remove the value `_` associated with key `all`
+
+        for d in logicArchs:
+            createDirectoryWithYamls(baseDir / d, d, "yaml")
+
+        result = TensileCreateLibrary.findLogicFiles(baseDir, logicArchs, lazyLoading, experimentalDir)
+        expected = findLogicFiles_oldLogic(baseDir, logicArchs, lazyLoading, experimentalDir)
+        return result == expected
+    
+    def outputMatchesOldLogic3():
+        baseDir, lazyLoading, experimentalDir = setup()
+        logicArchs = set(Common.architectureMap["all"])
+
+        for d in logicArchs:
+            createDirectoryWithYamls(baseDir / d, d, "yaml")
+
+        result = TensileCreateLibrary.findLogicFiles(baseDir, logicArchs, lazyLoading, experimentalDir)
+        expected = findLogicFiles_oldLogic(baseDir, logicArchs, lazyLoading, experimentalDir)
+        return result == expected
+
+    def verifyYamlAndYml():
+        baseDir, lazyLoading, experimentalDir = setup()
+        # Create directory structure with files that *don't* have arch in filename
+        logicArchs = set(Common.architectureMap.values())
+        logicArchs.add("hip")
+        logicArchs.remove("_")
+
+        for d in logicArchs:
+            createDirectoryWithYamls(baseDir / "yaml" / d, d, "yaml")
+            createDirectoryWithYamls(baseDir / "yml" / d, d, "yml")
+
+        result = TensileCreateLibrary.findLogicFiles(baseDir, logicArchs, lazyLoading, experimentalDir)
+        expected = findLogicFiles_oldLogic(baseDir, logicArchs, lazyLoading, experimentalDir)
+        return len(result) == len(expected)*2
+
+    assert outputMatchesOldLogic1(), "Output differs from old logic, not backwards compatible."
+    assert outputMatchesOldLogic2(), "Output differs from old logic, not backwards compatible."
+    assert outputMatchesOldLogic3(), "Output differs from old logic, not backwards compatible."
+    assert verifyYamlAndYml(), "Output should have twice as many files as old logic (which only parses .yaml)"
+
+
+# ----------------
+# Helper functions
+# ----------------
+def createDirectoryWithYamls(currentDir, prefix, ext, depth=3, nChildren=3):
+    def recurse(currentDir, depth, nChildren):
+        if depth == 0:
+            return
+
+        currentDir.mkdir(parents=True, exist_ok=True)
+        file = f"{prefix}_{str(uuid.uuid4().hex)}.{ext}"
+        with open(currentDir/file, mode="w"):
+            pass
+
+        for n in range(nChildren):
+            recurse(currentDir / str(n), depth - 1, nChildren)
+    recurse(currentDir, depth, nChildren)
+
+
+def findLogicFiles_oldLogic(logicPath, logicArchs, lazyLoading, experimentalDir):
+    # Recursive directory search
+    logicFiles = []
+    for root, dirs, files in os.walk(str(logicPath)):
+        logicFiles += [os.path.join(root, f) for f in files
+                        if os.path.splitext(f)[1]==".yaml" \
+                        and (any(logicArch in os.path.splitext(f)[0] for logicArch in logicArchs) \
+                        or "hip" in os.path.splitext(f)[0]) ]
+
+    if not lazyLoading:
+        logicFiles = [f for f in logicFiles if not experimentalDir in f]
+    return logicFiles

--- a/docs/src/api-reference/TensileCreateLibrary.rst
+++ b/docs/src/api-reference/TensileCreateLibrary.rst
@@ -6,3 +6,4 @@ TensileCreateLibrary
 ====================
 
 .. autofunction:: Tensile.TensileCreateLibrary::verifyManifest
+.. autofunction:: Tensile.TensileCreateLibrary::findLogicFiles


### PR DESCRIPTION
**Objectives:**
- Replace previous recursive search with glob during logic file discovery.
- Move logic file discovery into a function
- Add unit testing.
- Integrate the inline documentation into the documentation pipeline.

**Outcomes:**
- A new function has been added to *TensileCreateLibrary* named `findLogicFiles`
- Support for `.yml` extension in addition to `.yaml`
- Automatic API documentation and unit tests.

**Testing:**

Unit testing:
- New tests ensure that the results for new logic matches old (replaced) logic

Command to run unit tests (from Tensile/Tensile/Tests):
```
$ pytest unit/test_TensileCreateLibrary.py
```

Integration testing:
- Build rocBLAS via ./install.sh -c for both the source and destination branches (see Docker environment info below)
Compare generated Tensile manifests (build/release/Tensile/library/TensileManifest.txt) with diff; no changes.

**Notable changes:**
- Use `pathlib.Path` for path-based operations instead of `os`

**Docker environment info:**

```
$ cat /etc/os-release | head -1
PRETTY_NAME="Ubuntu 22.04.3 LTS"
```
```
$ apt show rocm-libs -a | head -2 | tail +2
Version: 6.1.2.60102-119~22.04
```
```
$ uname -r
5.15.0-86-generic
```