### PR TITLE
Replace YAML operations with C libyaml backend

### DIFF
--- a/HostLibraryTests/configs/ConvertYAML.py
+++ b/HostLibraryTests/configs/ConvertYAML.py
@@ -55,7 +55,7 @@ def merge_libraries(args):
 
     with open(outFile, 'w') as outf:
         if True:
-            yaml.dump(outData, outf)
+            yaml.dump(outData, outf, yaml.CSafeDumper)
         else:
             import json
             json.dump(outData, outf, sort_keys=True, indent=2, separators=(",", ": "))
@@ -82,7 +82,7 @@ def convert_one(args):
 
     with open(args[1], 'w') as outFile:
         if True:
-            yaml.dump(outData, outFile)
+            yaml.dump(outData, outFile, yaml.CSafeDumper)
         else:
             import json
             json.dump(outData, outFile, sort_keys=True, indent=2, separators=(",", ": "))

--- a/Tensile/BenchmarkSplitter.py
+++ b/Tensile/BenchmarkSplitter.py
@@ -39,7 +39,7 @@ class BenchmarkSplitter(object):
     @staticmethod
     def __readConfigFile(benchmarkConfigFile):
         with open(benchmarkConfigFile) as f:
-            data = yaml.safe_load(f)
+            data = yaml.load(f, yaml.CSafeLoader)
         return data
 
     # data: a loaded .yaml file
@@ -191,4 +191,4 @@ class BenchmarkSplitter(object):
         for i in range(len(benchmarksBySize)):
             outFileName = BenchmarkSplitter.__appendFileNameSuffix(outputFileBase, i, separator, suffixFormat)
             with open(outFileName, "w") as f:
-                yaml.safe_dump(benchmarksBySize[i], f)
+                yaml.dump(benchmarksBySize[i], f, yaml.CSafeDumper)

--- a/Tensile/CustomKernels.py
+++ b/Tensile/CustomKernels.py
@@ -60,6 +60,6 @@ def getCustomKernelConfigAndAssembly(name, directory=globalParameters["CustomKer
 def getCustomKernelConfig(name, directory=globalParameters["CustomKernelDirectory"]):
     rawConfig, _ = getCustomKernelConfigAndAssembly(name, directory)
     try:
-        return yaml.safe_load(rawConfig)["custom.config"]
+        return yaml.load(rawConfig, yaml.CSafeLoader)["custom.config"]
     except yaml.scanner.ScannerError as e:
         raise RuntimeError("Failed to read configuration for custom kernel: {0}\nDetails:\n{1}".format(name, e))

--- a/Tensile/GenerateSummations.py
+++ b/Tensile/GenerateSummations.py
@@ -140,7 +140,7 @@ def GenerateSummations(userArgs):
         tensileLibraryFile = os.path.join(libPath, "library", "TensileLibrary.yaml")
 
         stream = open(tensileLibraryFile, "r")
-        tensileLibrary = yaml.load(stream, yaml.SafeLoader)
+        tensileLibrary = yaml.load(stream, yaml.CSafeLoader)
         stream.close()
 
         libSolutions = tensileLibrary["solutions"]

--- a/Tensile/LibraryIO.py
+++ b/Tensile/LibraryIO.py
@@ -74,7 +74,7 @@ def writeYAML(filename, data, **kwargs):
         kwargs["default_flow_style"] = None
 
     with open(filename, "w") as f:
-        yaml.dump(data, f, **kwargs)
+        yaml.dump(data, f, yaml.CSafeDumper, **kwargs)
 
 
 def writeMsgPack(filename, data):
@@ -109,7 +109,7 @@ def writeSolutions(filename, problemSizes, solutions, cache=False):
                 #FIXME-problem, this ignores strides:
                 f.write("  - Exact: {}\n".format(problemExact))
 
-        yaml.dump(solutionStates, f, default_flow_style=None)
+        yaml.dump(solutionStates, f, yaml.CSafeDumper, default_flow_style=None)
 
 
 ###############################
@@ -118,7 +118,7 @@ def writeSolutions(filename, problemSizes, solutions, cache=False):
 def readYAML(filename):
     """Reads and returns YAML data from file."""
     with open(filename, "r") as f:
-        data = yaml.load(f, yaml.SafeLoader)
+        data = yaml.load(f, yaml.CSafeLoader)
     return data
 
 

--- a/Tensile/TensileMergeLibrary.py
+++ b/Tensile/TensileMergeLibrary.py
@@ -402,7 +402,7 @@ def avoidRegressions(originalDir, incrementalDir, outputPath, forceMerge, trimSi
         updateSizesAndSols(origData, mergedLogic)
 
         with open(os.path.join(outputPath, basename), "w") as outFile:
-            yaml.safe_dump(origData, outFile, default_flow_style=None)
+            yaml.dump(origData, outFile, yaml.CSafeDumper, default_flow_style=None)
         msg("File written to", os.path.join(outputPath, basename))
         msg("------------------------------")
 

--- a/Tensile/Tests/extended/convolution_config/YamlBuilder/YamlBuilder.py
+++ b/Tensile/Tests/extended/convolution_config/YamlBuilder/YamlBuilder.py
@@ -216,7 +216,7 @@ class YamlBuilder:
 
     def write(self, fname):
         with open(str(fname), "w") as f:
-            yaml.dump(self.doc, f, default_flow_style=None)
+            yaml.dump(self.doc, f, yaml.CSafeDumper, default_flow_style=None)
 
     @classmethod
     def findAvailableArchs(self):

--- a/Tensile/Tests/unit/test_CustomKernels.py
+++ b/Tensile/Tests/unit/test_CustomKernels.py
@@ -40,7 +40,7 @@ def test_FindCustomKernel(objs):
     except:
         assert False
 
-configResult = yaml.safe_load(
+configResult = yaml.load(
 """
 ProblemType:
     OperationType: GEMM
@@ -56,7 +56,7 @@ WorkGroup: [  8, 16,  1 ]
 DepthU: 8
 VectorWidth: 4
 AssertSizeEqual: {3: 512}
-AssertSizeMultiple: {0: 128, 1: 128}"""
+AssertSizeMultiple: {0: 128, 1: 128}""", yaml.CSafeLoader
 )
 
 # TODO when more custom kernels have been added - expand these lists

--- a/Tensile/Tests/unit/test_LibraryIO.py
+++ b/Tensile/Tests/unit/test_LibraryIO.py
@@ -161,18 +161,18 @@ def createLibraryLogicList(arch_str, suffix_str, fp16AltImpl, fp16AltImplRound):
     sol0["ProblemType"] = problemType
 
     # other components
-    prefixData = yaml.load(version_l + arch_str, yaml.SafeLoader)
-    sizeData = yaml.load(sizes, yaml.SafeLoader)
-    suffixData = yaml.load(suffix_str, yaml.SafeLoader)
+    prefixData = yaml.load(version_l + arch_str, yaml.CSafeLoader)
+    sizeData = yaml.load(sizes, yaml.CSafeLoader)
+    suffixData = yaml.load(suffix_str, yaml.CSafeLoader)
 
     # handle fp16AltImpl and combine
     rv = prefixData + [problemType] + [[sol0, sol1]] + sizeData + suffixData
     if fp16AltImpl:
-        fp16AltData = yaml.load(fp16AltImpl_l, yaml.SafeLoader)
+        fp16AltData = yaml.load(fp16AltImpl_l, yaml.CSafeLoader)
         rv += fp16AltData
 
     if fp16AltImplRound:
-        fp16AltRoundData = yaml.load(fp16AltImplRound_l, yaml.SafeLoader)
+        fp16AltRoundData = yaml.load(fp16AltImplRound_l, yaml.CSafeLoader)
         rv += fp16AltRoundData
 
     return rv
@@ -203,18 +203,18 @@ def createLibraryLogicDict(arch_str, suffix_str, lib_str, fp16AltImpl_str, fp16A
     sol0["ProblemType"] = problemType
 
     # other components
-    prefixData = yaml.load(version_d + arch_str, yaml.SafeLoader)
-    libData = yaml.load(lib_str, yaml.SafeLoader)
-    suffixData = yaml.load(suffix_str, yaml.SafeLoader)
+    prefixData = yaml.load(version_d + arch_str, yaml.CSafeLoader)
+    libData = yaml.load(lib_str, yaml.CSafeLoader)
+    suffixData = yaml.load(suffix_str, yaml.CSafeLoader)
 
     # handle fp16AltImpl and combine
     fp16Data = {}
     if fp16AltImpl_str is not None:
-        fp16Data = yaml.load(fp16AltImpl_str, yaml.SafeLoader)
+        fp16Data = yaml.load(fp16AltImpl_str, yaml.CSafeLoader)
 
     fp16RoundData = {}
     if fp16AltImplRound_str is not None:
-        fp16RoundData = yaml.load(fp16AltImplRound_str, yaml.SafeLoader)
+        fp16RoundData = yaml.load(fp16AltImplRound_str, yaml.CSafeLoader)
 
     data = {**prefixData, **libData, **suffixData, **fp16Data, **fp16RoundData}
     data["ProblemType"] = problemType

--- a/Tensile/Tests/unit/test_TensileCreateLibrary.py
+++ b/Tensile/Tests/unit/test_TensileCreateLibrary.py
@@ -109,7 +109,7 @@ def test_WriteClientLibraryFromSolutions(tmpdir):
         stream = open(tensileYamlFilePath, "r")
     except IOError:
         mylogger.error("Cannot open file: %s" % tensileYamlFilePath)
-    config = yaml.load(stream, yaml.SafeLoader)
+    config = yaml.load(stream, yaml.CSafeLoader)
     stream.close()
     actualSolutions = config["solutions"]
 
@@ -123,7 +123,7 @@ def test_WriteClientLibraryFromSolutions(tmpdir):
         stream = open(metadataYamlFilePath, "r")
     except IOError:
         mylogger.error("Cannot open file: %s" % metadataYamlFilePath)
-    metadata = yaml.load(stream, yaml.SafeLoader)
+    metadata = yaml.load(stream, yaml.CSafeLoader)
     stream.close()
     actualProblemType = metadata["ProblemType"]
 

--- a/Tensile/Tests/unit/test_mergeLogic.py
+++ b/Tensile/Tests/unit/test_mergeLogic.py
@@ -220,20 +220,16 @@ def checkUniqueSolution(solutionPool):
   (notTrimmedSize, [[1024,1024,1,1024],[128,128,1,128]])
   ])
 def test_fixSizeInconsistencies(sizes, expected):
-  data = yaml.load(sizes, yaml.SafeLoader)
+  data = yaml.load(sizes, yaml.CSafeLoader)
   data_ = fixSizeInconsistencies(data[0], "dummy")
 
   for [size, [_,_]], expected_ in zip(data_[0], expected):
     assert size == expected_
-  # print final yaml for visual inspection
-  # stream = io.StringIO("")
-  # yaml.safe_dump(data_, stream, default_flow_style=None)
-  # print(stream.getvalue())
 
 @pytest.mark.parametrize("input,expectedNumKernelRemoved", [(baseLogic, 1),
                                                             (incLogic, 0)])
 def test_removeUnusedKernels(input, expectedNumKernelRemoved):
-  data = yaml.load(input, yaml.SafeLoader)
+  data = yaml.load(input, yaml.CSafeLoader)
   dataFiltered, numKernelRemoved = removeUnusedKernels(data)
 
   # test if number of solution removed is correct
@@ -269,18 +265,13 @@ def test_removeUnusedKernels(input, expectedNumKernelRemoved):
   ["InUseForSize256", "InUseForSize128or64", "InUseForSize128or64"]),
 ])
 def test_mergeLogic(baseLogic, incLogic, expectedStats, expectedSizes, expectedSolutions):
-  baseData = yaml.load(baseLogic, yaml.SafeLoader)
-  incData = yaml.load(incLogic, yaml.SafeLoader)
+  baseData = yaml.load(baseLogic, yaml.CSafeLoader)
+  incData = yaml.load(incLogic, yaml.CSafeLoader)
 
   mergedData, *stats = mergeLogic(baseData, incData, False)
 
   # check if stats are as expected
   assert stats == expectedStats
-
-  # print final yaml for visual inspection
-  # stream = io.StringIO("")
-  # yaml.safe_dump(mergedData, stream, default_flow_style=None)
-  # print(stream.getvalue())
 
   # check if solution matches expected. assumes SolutionNameMin is uniqueSolution
   # (which is satisfied by the test data given here)
@@ -296,7 +287,7 @@ def test_mergeLogic(baseLogic, incLogic, expectedStats, expectedSizes, expectedS
 
 @pytest.mark.parametrize("input,expected", [(uniqueSolution, True), (notUniqueSolution, False)])
 def test_checkUniqueSolution(input, expected):
-  data = yaml.load(input, yaml.SafeLoader)
+  data = yaml.load(input, yaml.CSafeLoader)
   assert checkUniqueSolution(data[5]) == expected
 
 @pytest.mark.parametrize("baseLogic, incLogic, expectedSizesYaml, expectedSolutions", [
@@ -311,9 +302,9 @@ def test_checkUniqueSolution(input, expected):
    mfmaMergeResNotMatchingMFMA, ["MFMA_base", "VALU_base", "MFMA_inc", "VALU_inc"])
 ])
 def test_mfmaMergeLogic(baseLogic, incLogic, expectedSizesYaml, expectedSolutions):
-  baseData      = yaml.load(baseLogic, yaml.SafeLoader)
-  incData       = yaml.load(incLogic,  yaml.SafeLoader)
-  expectedSizes = yaml.load(expectedSizesYaml, yaml.SafeLoader)[0]
+  baseData      = yaml.load(baseLogic, yaml.CSafeLoader)
+  incData       = yaml.load(incLogic,  yaml.CSafeLoader)
+  expectedSizes = yaml.load(expectedSizesYaml, yaml.CSafeLoader)[0]
 
   mergedData, _, _, _ = mergeLogic(baseData, incData, False, True, True)
 

--- a/Tensile/Tests/yaml_only/test_config.py
+++ b/Tensile/Tests/yaml_only/test_config.py
@@ -100,7 +100,7 @@ def configMarks(filepath, rootDir, availableArchs):
 
     try:
         with open(filepath) as f:
-            doc = yaml.load(f, yaml.SafeLoader)
+            doc = yaml.load(f, yaml.CSafeLoader)
     except yaml.parser.ParserError:
         marks.append(pytest.mark.syntax_error)
         return marks

--- a/Tensile/Utilities/archive/merge_rocblas_yaml_files.py
+++ b/Tensile/Utilities/archive/merge_rocblas_yaml_files.py
@@ -65,7 +65,7 @@ class LibraryLogic:
         stream = open(filename, "r")
       except IOError:
         printExit("Cannot open file: %s" % filename )
-      data = yaml.load(stream, yaml.SafeLoader)
+      data = yaml.load(stream, yaml.CSafeLoader)
 
       if isinstance(data, list):
 
@@ -243,7 +243,7 @@ class LibraryLogic:
     else:
       try:
         stream = open(filename, "w")
-        yaml.safe_dump(data, stream, default_flow_style=None)
+        yaml.dump(data, stream, yaml.CSafeDumper, default_flow_style=None)
         stream.close()
       except IOError:
         printExit("Cannot open file: %s" % filename)

--- a/Tensile/Utilities/merge.py
+++ b/Tensile/Utilities/merge.py
@@ -134,7 +134,7 @@ def loadData(filename):
         print("Cannot open file: ", filename)
         sys.stdout.flush()
         sys.exit(-1)
-    data = yaml.load(stream, yaml.SafeLoader)
+    data = yaml.load(stream, yaml.CSafeLoader)
     return data
 
 # this is for complying the behavior of legacy merge script, where incremental logic
@@ -390,7 +390,7 @@ def avoidRegressions(originalDir, incrementalDir, outputPath, forceMerge, trimSi
         msg(stats[0], "size(s) and", stats[1], "kernel(s) added,", stats[2], "kernel(s) removed")
 
         with open(os.path.join(outputPath, basename), "w") as outFile:
-            yaml.safe_dump(mergedData,outFile,default_flow_style=None)
+            yaml.dump(mergedData, outFile, yaml.CSafeDumper, default_flow_style=None)
         msg("File written to", os.path.join(outputPath, basename))
         msg("------------------------------")
 
@@ -434,7 +434,7 @@ def mergePartialLogics(partialLogicFilePaths, outputDir, forceMerge, trimSize=Tr
     baseFileName = os.path.basename(baseLogicFile)
     outputFilePath = os.path.join(outputDir, baseFileName)
     with open(outputFilePath, "w") as outFile:
-        yaml.safe_dump(baseLogicData, outFile, default_flow_style=None)
+        yaml.dump(baseLogicData, outFile, yaml.CSafeDumper, default_flow_style=None)
     msg("File written to", outputFilePath)
     msg("------------------------------")
 

--- a/tuning/automation/ConvertToEfficiency.py
+++ b/tuning/automation/ConvertToEfficiency.py
@@ -76,7 +76,7 @@ def main():
     mfmaKey = "mfma" if args.mfma else "non_mfma"
 
     with open(args.specs) as y:
-        specs = yaml.safe_load(y)
+        specs = yaml.load(y, yaml.CSafeLoader)
 
     try:
         os.makedirs(args.outDir)
@@ -89,7 +89,7 @@ def main():
             print(f)
             with open(f) as y:
 
-                data = yaml.safe_load(y)
+                data = yaml.load(y, yaml.CSafeLoader)
 
                 sched = data[1]
                 if args.x:
@@ -127,7 +127,7 @@ def main():
             outFile = os.path.join(args.outDir, fName)
 
             with open(outFile, "w") as y:
-                yaml.safe_dump(data, y, default_flow_style=None)
+                yaml.dump(data, y, yaml.CSafeDumper, default_flow_style=None)
 
 if __name__ == "__main__":
     main()

--- a/tuning/automation/RemoveSizes.py
+++ b/tuning/automation/RemoveSizes.py
@@ -55,7 +55,7 @@ def main():
         print("Sizes File  : " + args.sizeList)
 
     with open(args.inLogic) as inFile:
-        logicData = yaml.safe_load(inFile)
+        logicData = yaml.load(inFile, yaml.CSafeLoader)
 
     mapping = logicData[7]
     if args.verbose:
@@ -82,7 +82,7 @@ def main():
         print("Final size count = {}".format(len(mapping)))
 
     with open(args.outLogic, "w") as outFile:
-        yaml.safe_dump(logicData, outFile, default_flow_style=None, sort_keys=False, width=5000)
+        yaml.dump(logicData, outFile, yaml.CSafeDumper, default_flow_style=None, sort_keys=False, width=5000)
 
     if args.verbose:
         print("Done writing new logic file")

--- a/tuning/automation/TuningConfiguration.py
+++ b/tuning/automation/TuningConfiguration.py
@@ -120,7 +120,7 @@ class TuningConfiguration(object):
             except IOError:
                 printExit("Cannot open file: %s" % filename )
 
-            data = yaml.load(stream, yaml.SafeLoader)
+            data = yaml.load(stream, yaml.CSafeLoader)
 
             if CONST.GlobalParameters in data:
                 self.__globalParameters = data[CONST.GlobalParameters]
@@ -188,18 +188,17 @@ class TuningConfiguration(object):
 
             if self.globalParameters:
                 dataGlobal[CONST.GlobalParameters] = self.globalParameters
-                yaml.dump(dataGlobal, stream, default_flow_style=None, width=1024)
+                yaml.dump(dataGlobal, stream, yaml.CSafeDumper, default_flow_style=None, width=1024)
                 stream.flush()
 
             if self.benchmarkProblems:
                 dataBenchmark[CONST.BenchmarkProblems] = self.benchmarkProblems
-                #yaml.dump(dataBenchmark, stream, default_flow_style=None, default_style='', width=1024)
-                yaml.safe_dump(dataBenchmark, stream, default_flow_style=None)
+                yaml.dump(dataBenchmark, stream, yaml.CSafeDumper, default_flow_style=None)
                 stream.flush()
 
             if self.libraryLogic:
                 dataLibraryLogic[CONST.LibraryLogic] = self.libraryLogic
-                yaml.dump(dataLibraryLogic, stream, default_flow_style=None, width=1024)
+                yaml.dump(dataLibraryLogic, stream, yaml.CSafeDumper, default_flow_style=None, width=1024)
                 stream.flush()
 
             if self.libraryClient:

--- a/tuning/automation/rocblas-benchInputCreator.py
+++ b/tuning/automation/rocblas-benchInputCreator.py
@@ -180,7 +180,7 @@ def dumpYaml(outDir, outputfile,postfix, content):
     name = outputfile+postfix
     benchPath = os.path.join(outDir, name)
     with open(benchPath, "w") as f:
-        yaml.safe_dump(content, f, default_flow_style=None, sort_keys=False, width=5000)
+        yaml.dump(content, f, yaml.CSafeDumper, default_flow_style=None, sort_keys=False, width=5000)
         f.write(f"# End of {name} \n")
 
 def createYaml(args, outputfile, problem, sizeMappings, verify):
@@ -327,7 +327,7 @@ def main():
         print(f" working on {output}")
         yamlName = os.path.join(args.libLogic,libname)
         with open(yamlName) as f:
-            logicData = yaml.safe_load(f)
+            logicData = yaml.load(f, yaml.CSafeLoader)
 
         try:
             os.makedirs(args.outDir)

--- a/tuning/automation/rocblas-parser.py
+++ b/tuning/automation/rocblas-parser.py
@@ -355,7 +355,7 @@ def create_rocBLAS_bench(benchFile, matrices,verify,initialization):
         # write output
         with open(benchFile, "w") as f:
             if len(bench) > 0:
-                yaml.safe_dump(bench, f, default_flow_style=None, sort_keys=False, width=5000)
+                yaml.dump(bench, f, yaml.CSafeDumper, default_flow_style=None, sort_keys=False, width=5000)
 
 def main():
     args = parseBenchCofnig()    


### PR DESCRIPTION
**Objectives**
- Reduce the runtime of Tensile applications and any downstream build chains by replacing the standard PyYAML Loader and Dumper with the C libyaml backend.

**Testing:**

*TensileCreateLibrary*

When timing the execution of *TensileCreateLibrary* on gfx90a architectures, the following differences were noted:
- Before (with SafeLoader): real   **6m26s**
- After (with CSafeLoader): real    **5m13s**
- Result: 19.0% runtime reduction

Command issued:
```bash
$ time Tensile/bin/TensileCreateLibrary ${rocblas_root}/library/src/blas3/Tensile/Logic/asm_full/aldebaran build_profiler HIP --merge-files --separate-architecture --lazy-library-loading --no-short-file-names --no-library-print-debug --code-object-version=default --cxx-compiler=hipcc --jobs=64 --library-format=msgpack --architecture=gfx90a
```

*rocBLAS*

When building *rocBLAS*, the following differences were noted:
- Before (with SafeLoader): real **53m46s**
- After (with CSafeLoader): real **51m57s**
- Result: 3.4% runtime reduction

Command issued:
```bash
$ ./install.sh
```