### PR TITLE
Factors client config logic from TensileCreateLibrary main into createClientConfig

### DIFF
--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -1101,8 +1101,8 @@ def findLogicFiles(path: Path, logicArchs: Set[str], lazyLoading: bool, experime
     return list(str(l) for l in logicFiles)
 
 def createClientConfig(outputPath: Path, masterFile: Path, codeObjectFiles: List[str], configFile: str = "best-solution.ini") -> None:
-    """Outputs a client config file corresponding to a master library file and code-object parameters 
-       created by a TensileCreateLibrary invocation. Also sets best-solution-mode to True.
+    """Outputs a client config file corresponding to a master library file and code-object parameters
+           created by a TensileCreateLibrary invocation. Also sets best-solution-mode to True.
     
     Args:
         outputPath: The path to the tensile output directory where output files are written.

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -1101,20 +1101,14 @@ def findLogicFiles(path: Path, logicArchs: Set[str], lazyLoading: bool, experime
     return list(str(l) for l in logicFiles)
 
 def createClientConfig(outputPath: Path, masterFile: Path, codeObjectFiles: List[str]) -> None:
-    """Outputs a client config file named best-solution.ini corresponding a master library 
+    """Outputs a client config file named best-solution.ini corresponding to a master library 
        file and code-object parameters created by a TensileCreateLibrary invocation. Also
        sets best-solution-mode to True.
     
     Args:
         outputPath: The path to the tensile output directory where output files are written.
-        masterFile: Path to the master library file (.dat or .yaml) e.g.:
-
-          "tensile-out/library/TensileLibrary_lazy_gfx908.dat"
-
-        codeObjectFiles: List of code object files created by TensileCreateLibrary e.g.:
-          
-          ["tensile-out/library/TensileLibrary_Type_SS_Contraction_l_Alik_Bjlk_Cijk_Dijk_gfx908.hsaco', 
-           "tensile-out/library/TensileLibrary_Type_SS_Contraction_l_Ailk_Bljk_Cijk_Dijk_gfx908.hsaco", ... ]
+        masterFile: Path to the master library file (.dat or .yaml).
+        codeObjectFiles: List of code object files created by TensileCreateLibrary.
     """
     iniFile = outputPath / "best-solution.ini"
     

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -1100,20 +1100,20 @@ def findLogicFiles(path: Path, logicArchs: Set[str], lazyLoading: bool, experime
 
     return list(str(l) for l in logicFiles)
 
-def createClientConfig(outputPath: Path, masterFile: Path, codeObjectFiles: List[str]) -> None:
-    """Outputs a client config file named best-solution.ini corresponding to a master library 
-       file and code-object parameters created by a TensileCreateLibrary invocation. Also
-       sets best-solution-mode to True.
+def createClientConfig(outputPath: Path, masterFile: Path, codeObjectFiles: List[str], configFile: str = "best-solution.ini") -> None:
+    """Outputs a client config file corresponding to a master library file and code-object parameters 
+       created by a TensileCreateLibrary invocation. Also sets best-solution-mode to True.
     
     Args:
         outputPath: The path to the tensile output directory where output files are written.
         masterFile: Path to the master library file (.dat or .yaml).
         codeObjectFiles: List of code object files created by TensileCreateLibrary.
+        configFile: Name of config file written to the output directory.
     """
-    iniFile = outputPath / "best-solution.ini"
+    iniFile = outputPath / configFile
     
     def param(key, value):
-      f.write("{}={}\n".format(key, value))
+      f.write(f"{key}={value}\n")
 
     with open(iniFile, "w") as f:
       if not masterFile.is_file():
@@ -1126,7 +1126,7 @@ def createClientConfig(outputPath: Path, masterFile: Path, codeObjectFiles: List
           warnings.warn(UserWarning(f"{codeObject} does not exist. best-solution.ini may be invalid."))        
 
         param("code-object", outputPath / coFile)
-
+      
       param("best-solution", True)
 
 ################################################################################

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -1101,8 +1101,10 @@ def findLogicFiles(path: Path, logicArchs: Set[str], lazyLoading: bool, experime
     return list(str(l) for l in logicFiles)
 
 def createClientConfig(outputPath: Path, masterFile: Path, codeObjectFiles: List[str], configFile: str = "best-solution.ini") -> None:
-    """Outputs a client config file corresponding to a master library file and code-object parameters
-           created by a TensileCreateLibrary invocation. Also sets best-solution-mode to True.
+    """Generates a client config file.
+    
+    Generates a client config file corresponding to a master library file and code-object parameters
+    created by a TensileCreateLibrary invocation. Also sets best-solution-mode to True.
     
     Args:
         outputPath: The path to the tensile output directory where output files are written.

--- a/Tensile/Tests/unit/test_TensileCreateLibrary.py
+++ b/Tensile/Tests/unit/test_TensileCreateLibrary.py
@@ -307,28 +307,14 @@ def setupClientConfigTest(outputPath, masterLibrary, codeObjectFiles):
 
 
 def cleanClientConfigTest(outputPath: Path, masterLibrary, codeObjectFiles, configFile):
-    try:
+    with contextlib.suppress(FileNotFoundError):
         os.remove(configFile)
-    except:
-        pass
-    try:
         os.remove(masterLibrary)        
-    except:
-        pass
-
         for f in codeObjectFiles:
-            try:
-                os.remove(outputPath / f)
-            except:
-                pass
-        try:
-            next(outputPath.iterdir()).rmdir()
-        except:
-            pass
-        try:
-            outputPath.rmdir()
-        except:
-            pass
+            os.remove(outputPath / f)
+        next(outputPath.iterdir()).rmdir()
+        outputPath.rmdir()
+
 
 def createDirectoryWithYamls(currentDir, prefix, ext, depth=3, nChildren=3):
     def recurse(currentDir, depth, nChildren):

--- a/docs/src/api-reference/TensileCreateLibrary.rst
+++ b/docs/src/api-reference/TensileCreateLibrary.rst
@@ -5,5 +5,6 @@
 TensileCreateLibrary
 ====================
 
-.. autofunction:: Tensile.TensileCreateLibrary::verifyManifest
+.. autofunction:: Tensile.TensileCreateLibrary::createClientConfig    
 .. autofunction:: Tensile.TensileCreateLibrary::findLogicFiles
+.. autofunction:: Tensile.TensileCreateLibrary::verifyManifest


### PR DESCRIPTION
A portion of the TensileCreateLibrary related to creating a client config file main was factored into a function called `createClientConfig` to improve readability, testability, profilability and documentation. The function is now unit tested and documented. Further, when profiling TensileCreateLibrary, the time spent doing work in this function will be clearly associated with the function.