### PR TITLE
Refactor sanity check in TensileCreateLibrary

### DIFF
--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -1127,6 +1127,7 @@ def sanityCheck(srcLibPaths: List[str], asmLibPaths: List[str], codeObjectPaths:
         if extraLibs:
             raise ValueError(f"Sanity check failed; missing expected code object files: "\
                     f"{[p.name for p  in extraLibs]}")
+
 def createClientConfig(outputPath: Path, masterFile: Path, codeObjectFiles: List[str], configFile: str = "best-solution.ini") -> None:
     """Generates a client config file.
     

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -1099,6 +1099,33 @@ def findLogicFiles(path: Path, logicArchs: Set[str], lazyLoading: bool, experime
 
     return list(str(l) for l in logicFiles)
 
+def sanityCheck(srcLibPaths: List[str], asmLibPaths: List[str], codeObjectPaths: List[str], genSourcesAndExit: bool):
+    """Verifies that generated code object paths match associated library paths.
+
+    Args:
+        srcLibPaths: Source library paths (.hasco).
+        asmLibPaths: Assembly library paths (.co).
+        coPaths: Code object paths containing generated kernels; should contain all assembly
+            and source library paths.
+        genSourcesAndExit: Flag identifying whether only source file should be generated.
+
+    Raises:
+        ValueError: If code object paths do not match library paths.
+    """
+    libPaths = set([Path(p).resolve() for p in srcLibPaths + asmLibPaths])
+    coPaths = set([Path(p).resolve() for p in codeObjectPaths])
+
+    extraCodeObjects = coPaths - libPaths
+    if extraCodeObjects:
+        raise ValueError(f"Sanity check failed; unexpected code object files: "\
+                f"{[p.name for p in extraCodeObjects]}")
+
+    if not genSourcesAndExit:
+        extraLibs = libPaths - coPaths
+        if extraLibs:
+            raise ValueError(f"Sanity check failed; missing expected code object files: "\
+                    f"{[p.name for p  in extraLibs]}")
+
 ################################################################################
 # Tensile Create Library
 ################################################################################
@@ -1312,20 +1339,12 @@ def TensileCreateLibrary():
   codeObjectFiles = writeKernels(outputPath, CxxCompiler, None, solutions,
                                              kernels, kernelHelperObjs, kernelWriterSource, kernelWriterAssembly)
 
-  bothLibSet = set(sourceLibPaths + asmLibPaths)
-  setA = set( map( os.path.normcase, set(codeObjectFiles) ) )
-  setB = set( map( os.path.normcase, bothLibSet ) )
-
-  sanityCheck0 = setA - setB
-  sanityCheck1 = setB - setA
+    
+  sanityCheck(sourceLibPaths, asmLibPaths, codeObjectFiles, globalParameters["GenerateSourcesAndExit"])
 
   if globalParameters["PrintCodeCommands"]:
-    print1("codeObjectFiles:", codeObjectFiles)
-    print1("sourceLibPaths + asmLibPaths:", sourceLibPaths + asmLibPaths)
-
-  assert len(sanityCheck0) == 0, "Unexpected code object files: {}".format(sanityCheck0)
-  if not globalParameters["GenerateSourcesAndExit"]:
-    assert len(sanityCheck1) == 0, "Missing expected code object files: {}".format(sanityCheck1)
+      print1(f"codeObjectFiles: {codeObjectFiles}")
+      print1(f"sourceLibPaths + asmLibPaths: {sourceLibPaths + asmLibPaths}")
 
   archs = [gfxName(arch) for arch in globalParameters['SupportedISA'] \
              if globalParameters["AsmCaps"][arch]["SupportedISA"]]

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -1103,7 +1103,7 @@ def sanityCheck(srcLibPaths: List[str], asmLibPaths: List[str], codeObjectPaths:
     """Verifies that generated code object paths match associated library paths.
 
     Args:
-        srcLibPaths: Source library paths (.hasco).
+        srcLibPaths: Source library paths (.hsaco).
         asmLibPaths: Assembly library paths (.co).
         coPaths: Code object paths containing generated kernels; should contain all assembly
             and source library paths.

--- a/Tensile/Tests/unit/test_TensileCreateLibrary.py
+++ b/Tensile/Tests/unit/test_TensileCreateLibrary.py
@@ -295,6 +295,7 @@ def test_sanityCheck():
             sanityCheck_oldLogic(srcPaths, asmPaths, coPathsMissing, False)
         except:
             raise Exception
+
 def test_createClientConfig():
     
     outputPath: Path = Path.cwd() / "my-output"

--- a/docs/src/api-reference/TensileCreateLibrary.rst
+++ b/docs/src/api-reference/TensileCreateLibrary.rst
@@ -9,3 +9,4 @@ TensileCreateLibrary
 .. autofunction:: Tensile.TensileCreateLibrary::findLogicFiles
 .. autofunction:: Tensile.TensileCreateLibrary::sanityCheck
 .. autofunction:: Tensile.TensileCreateLibrary::verifyManifest
+

--- a/docs/src/api-reference/TensileCreateLibrary.rst
+++ b/docs/src/api-reference/TensileCreateLibrary.rst
@@ -7,3 +7,4 @@ TensileCreateLibrary
 
 .. autofunction:: Tensile.TensileCreateLibrary::verifyManifest
 .. autofunction:: Tensile.TensileCreateLibrary::findLogicFiles
+.. autofunction:: Tensile.TensileCreateLibrary::sanityCheck


### PR DESCRIPTION
**Objective(s)**

Improve testing coverage for *TensileCreateLibrary* by moving sanity check code to its own function and adding tests.

**Outcome(s)**
- A new function has been added to *TensileCreateLibrary.py* called `sanityCheck`.
- Tests for this function have been added.

**Notable changes**

None

**Testing**

Standard Tensile Framework tests.

**Docker environment info**
```
$ cat /etc/os-release | head -1
PRETTY_NAME="Ubuntu 22.04.3 LTS"
```
```
$ apt show rocm-libs -a | head -2 | tail +2
Version: 6.1.2.60102-119~22.04
```
```
$ uname -r
5.15.0-86-generic
```