### PR TITLE
Update clang support for windows

### DIFF
--- a/Tensile/ClientExecutable.py
+++ b/Tensile/ClientExecutable.py
@@ -27,7 +27,7 @@ import os
 import subprocess
 
 from . import Common
-from .Common import globalParameters, print2, supportedLinuxCompiler
+from .Common import globalParameters, print2, supportedCompiler
 from .Parallel import CPUThreadCount
 
 def cmake_path(os_path):
@@ -79,8 +79,8 @@ def clientExecutableEnvironment(builddir=None):
         builddir = os.path.join(globalParameters["OutputPath"], globalParameters["ClientBuildPath"])
     builddir = Common.ensurePath(builddir)
 
-    CxxCompiler = "clang++.exe" if ((os.name == "nt") and supportedLinuxCompiler(globalParameters['CxxCompiler'])) else globalParameters['CxxCompiler']
-    CCompiler   = "clang.exe"   if ((os.name == "nt") and supportedLinuxCompiler(globalParameters['CxxCompiler'])) else globalParameters['CCompiler']
+    CxxCompiler = "clang++.exe" if ((os.name == "nt") and supportedCompiler(globalParameters['CxxCompiler'])) else globalParameters['CxxCompiler']
+    CCompiler   = "clang.exe"   if ((os.name == "nt") and supportedCompiler(globalParameters['CxxCompiler'])) else globalParameters['CCompiler']
 
     options = {'CMAKE_BUILD_TYPE': globalParameters["CMakeBuildType"],
                'TENSILE_USE_MSGPACK': 'ON',

--- a/Tensile/ClientExecutable.py
+++ b/Tensile/ClientExecutable.py
@@ -80,7 +80,7 @@ def clientExecutableEnvironment(builddir=None):
     builddir = Common.ensurePath(builddir)
 
     CxxCompiler = "clang++.exe" if ((os.name == "nt") and supportedCompiler(globalParameters['CxxCompiler'])) else globalParameters['CxxCompiler']
-    CCompiler   = "clang.exe"   if ((os.name == "nt") and supportedCompiler(globalParameters['CxxCompiler'])) else globalParameters['Cxxompiler']
+    CCompiler   = "clang.exe"   if ((os.name == "nt") and supportedCompiler(globalParameters['CxxCompiler'])) else globalParameters['CxxCompiler']
 
     options = {'CMAKE_BUILD_TYPE': globalParameters["CMakeBuildType"],
                'TENSILE_USE_MSGPACK': 'ON',

--- a/Tensile/ClientExecutable.py
+++ b/Tensile/ClientExecutable.py
@@ -80,7 +80,7 @@ def clientExecutableEnvironment(builddir=None):
     builddir = Common.ensurePath(builddir)
 
     CxxCompiler = "clang++.exe" if ((os.name == "nt") and supportedCompiler(globalParameters['CxxCompiler'])) else globalParameters['CxxCompiler']
-    CCompiler   = "clang.exe"   if ((os.name == "nt") and supportedCompiler(globalParameters['CxxCompiler'])) else globalParameters['CCompiler']
+    CCompiler   = "clang.exe"   if ((os.name == "nt") and supportedCompiler(globalParameters['CxxCompiler'])) else globalParameters['Cxxompiler']
 
     options = {'CMAKE_BUILD_TYPE': globalParameters["CMakeBuildType"],
                'TENSILE_USE_MSGPACK': 'ON',

--- a/Tensile/ClientExecutable.py
+++ b/Tensile/ClientExecutable.py
@@ -80,7 +80,7 @@ def clientExecutableEnvironment(builddir=None):
     builddir = Common.ensurePath(builddir)
 
     CxxCompiler = "clang++.exe" if ((os.name == "nt") and supportedCompiler(globalParameters['CxxCompiler'])) else globalParameters['CxxCompiler']
-    CCompiler   = "clang.exe"   if ((os.name == "nt") and supportedCompiler(globalParameters['CxxCompiler'])) else globalParameters['CxxCompiler']
+    CCompiler   = "clang.exe"   if ((os.name == "nt") and supportedCompiler(globalParameters['CxxCompiler'])) else globalParameters['CCompiler']
 
     options = {'CMAKE_BUILD_TYPE': globalParameters["CMakeBuildType"],
                'TENSILE_USE_MSGPACK': 'ON',

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -261,8 +261,8 @@ else:
   globalParameters["RuntimeLanguage"] = "HIP"
 
 globalParameters["CodeObjectVersion"] = "default"
-globalParameters["CxxCompiler"] = "amdclang++"
-globalParameters["CCompiler"] = "amdclang"
+globalParameters["CxxCompiler"] = "amdclang++" if os.name != "nt" else "clang++"
+globalParameters["CCompiler"] = "amdclang" if os.name != "nt" else "clang"
 globalParameters["Architecture"] = "all"
 
 # might be deprecated
@@ -330,16 +330,15 @@ def getArchitectureName(gfxName: str) -> Optional[str]:
     return None
 
 def supportedLinuxCompiler(compiler: str) -> bool:
-  """ Determines if compiler is supported by Tensile
+  """ Determines if compiler is supported by Tensile.
+
       Args:
           The name of a compiler to test for support.
       
       Return:
           If supported True; otherwise, False.
   """
-  if (compiler == "hipcc" or compiler == "amdclang++"): return True
-
-  return False
+  return (compiler == "hipcc" or compiler == "amdclang++" or compiler == "clang++")
 
 ################################################################################
 # Enumerate Valid Solution Parameters
@@ -2377,11 +2376,11 @@ def assignGlobalParameters( config ):
   
   # This may not be sufficient for amdclang
   try:
+    compiler = "hipcc"
     if os.name == "nt":
-      compileArgs = ['perl'] + [which('hipcc')] + ['--version']
+      compileArgs = ['perl'] + [which(compiler)] + ['--version']
       output = subprocess.run(compileArgs, check=True, stdout=subprocess.PIPE).stdout.decode()
     else:
-      compiler = "hipcc"
       output = subprocess.run([compiler, "--version"], check=True, stdout=subprocess.PIPE).stdout.decode()
 
     for line in output.split('\n'):

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -2389,24 +2389,21 @@ def assignGlobalParameters( config ):
   # The alternative would be to install the `distro` package.
   # See https://docs.python.org/3.7/library/platform.html#platform.linux_distribution
   
-  def getHipccVersion():
-    try:
-      compiler = "hipcc"
-      if os.name == "nt":
-        compileArgs = ['perl'] + [which(compiler)] + ['--version']
-        output = subprocess.run(compileArgs, check=True, stdout=subprocess.PIPE).stdout.decode()
-      else:
-        output = subprocess.run([compiler, "--version"], check=True, stdout=subprocess.PIPE).stdout.decode()
+def getHipccVersion():
+  try:
+    compiler = "hipcc"
+    if os.name == "nt":
+      compileArgs = ['perl'] + [which(compiler)] + ['--version']
+      output = subprocess.run(compileArgs, check=True, stdout=subprocess.PIPE).stdout.decode()
+    else:
+      output = subprocess.run([compiler, "--version"], check=True, stdout=subprocess.PIPE).stdout.decode()
+    result = next((line.split()[2] for line in output.split('\n') if 'HIP version' in line))
+    if result: print1("# Found  hipcc version " + result)
 
-      for line in output.split('\n'):
-        if 'HIP version' in line:
-          result = line.split()[2]
-          print1("# Found  hipcc version " + result)
-
-    except (subprocess.CalledProcessError, OSError) as e:
-        printWarning("Error: {} running {} {} ".format('hipcc', '--version',  e))
-        
     return result
+  
+  except (subprocess.CalledProcessError, OSError) as e:
+      print("Error: {} running {} {} ".format('hipcc', '--version',  e))
 
   globalParameters['HipClangVersion'] = getHipccVersion()
 

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -2327,8 +2327,8 @@ def assignGlobalParameters( config ):
   globalParameters["CmakeCxxCompiler"] = None
   if "CMAKE_CXX_COMPILER" in os.environ:
     globalParameters["CmakeCxxCompiler"] = os.environ.get("CMAKE_CXX_COMPILER")
-  if "CC" in os.environ:
-    globalParameters["CmakeCCompiler"] = os.environ.get("CC")    
+  if "CMAKE_C_COMPILER" in os.environ:
+    globalParameters["CmakeCCompiler"] = os.environ.get("CMAKE_C_COMPILER")
 
   globalParameters["ROCmBinPath"] = os.path.join(globalParameters["ROCmPath"], "bin")
 
@@ -2340,6 +2340,15 @@ def assignGlobalParameters( config ):
 
   if "CxxCompiler" in config:
     globalParameters["CxxCompiler"] = config["CxxCompiler"]
+    # Pair the CCompiler with CxxCompiler
+    if globalParameters["CxxCompiler"] == "hipcc":
+       globalParameters["CCompiler"] = "hipcc"
+    else:
+        if supportedCompiler(globalParameters["CxxCompiler"]):
+          globalParameters["CCompiler"] = "clang" if os.name == "nt" else "amdclang"
+        else: # unkown c++ compiler so set c compile rto be the same
+          globalParameters["CCompiler"] = globalParameters["CxxCompiler"]
+
   if "CCompiler" in config:
     globalParameters["CCompiler"] = config["CCompiler"]    
 

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -2389,21 +2389,21 @@ def assignGlobalParameters( config ):
   # The alternative would be to install the `distro` package.
   # See https://docs.python.org/3.7/library/platform.html#platform.linux_distribution
   
-def getHipccVersion():
-  try:
-    compiler = "hipcc"
-    if os.name == "nt":
-      compileArgs = ['perl'] + [which(compiler)] + ['--version']
-      output = subprocess.run(compileArgs, check=True, stdout=subprocess.PIPE).stdout.decode()
-    else:
-      output = subprocess.run([compiler, "--version"], check=True, stdout=subprocess.PIPE).stdout.decode()
-    result = next((line.split()[2] for line in output.split('\n') if 'HIP version' in line))
-    if result: print1("# Found  hipcc version " + result)
-
-    return result
+  def getHipccVersion():
+    try:
+      compiler = "hipcc"
+      if os.name == "nt":
+        compileArgs = ['perl'] + [which(compiler)] + ['--version']
+        output = subprocess.run(compileArgs, check=True, stdout=subprocess.PIPE).stdout.decode()
+      else:
+        output = subprocess.run([compiler, "--version"], check=True, stdout=subprocess.PIPE).stdout.decode()
+      result = next((line.split()[2] for line in output.split('\n') if 'HIP version' in line))
+      if result: print1("# Found  hipcc version " + result)
   
-  except (subprocess.CalledProcessError, OSError) as e:
-      print("Error: {} running {} {} ".format('hipcc', '--version',  e))
+      return result
+    
+    except (subprocess.CalledProcessError, OSError) as e:
+        print("Error: {} running {} {} ".format('hipcc', '--version',  e))
 
   globalParameters['HipClangVersion'] = getHipccVersion()
 

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -2405,7 +2405,9 @@ def assignGlobalParameters( config ):
 
     except (subprocess.CalledProcessError, OSError) as e:
         printWarning("Error: {} running {} {} ".format('hipcc', '--version',  e))
-  
+        
+    return result
+
   globalParameters['HipClangVersion'] = getHipccVersion()
 
   if "IgnoreAsmCapCache" in config:

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -1173,6 +1173,10 @@ def TensileCreateLibrary():
   logicPath = args.LogicPath
   outputPath = args.OutputPath
   CxxCompiler = args.CxxCompiler
+  if os.name == "nt" and CxxCompiler == "amdclang++":
+    CxxCompiler = "clang++"
+    args.CxxCompiler = "clang++"
+    printWarning("On windows using clang++.")
   libraryFormat = args.LibraryFormat
   print2("OutputPath: %s" % outputPath)
   ensurePath(outputPath)
@@ -1183,7 +1187,7 @@ def TensileCreateLibrary():
   arguments["Architecture"] = args.Architecture
   arguments["SeparateArchitectures"] = args.SeparateArchitectures
   arguments["LazyLibraryLoading"] = args.LazyLibraryLoading
-  arguments["CxxCompiler"] = args.CxxCompiler
+  arguments["CxxCompiler"] = CxxCompiler
   if args.CmakeCxxCompiler:
     os.environ["CMAKE_CXX_COMPILER"] = args.CmakeCxxCompiler
   arguments["MergeFiles"] = args.MergeFiles

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -1155,8 +1155,12 @@ def TensileCreateLibrary():
   argParser.add_argument("LogicPath",       help="Path to LibraryLogic.yaml files.")
   argParser.add_argument("OutputPath",      help="Where to write library files?")
   argParser.add_argument("RuntimeLanguage", help="Which runtime language?", choices=["OCL", "HIP", "HSA"])
-  argParser.add_argument("--cxx-compiler",           dest="CxxCompiler",       choices=['amdclang++', "clang++", "hipcc"], action="store", 
-                         default="amdclang++" if os.name != "nt" else "clang++")
+  
+  compilerChoices = ['amdclang++', "hipcc"] if os.name != "nt" else ["clang++", "hipcc"]
+  argParser.add_argument("--cxx-compiler", dest="CxxCompiler", choices=compilerChoices, action="store", default=compilerChoices[0],
+                         help="C++ compiler used when generating binaries."
+                         " On linux, amdclang++ or hipcc. On Windows clang++ or hipcc.")
+  
   argParser.add_argument("--cmake-cxx-compiler",     dest="CmakeCxxCompiler",  action="store")
   argParser.add_argument("--code-object-version",    dest="CodeObjectVersion", choices=["default", "V4", "V5"], action="store")
   argParser.add_argument("--architecture",           dest="Architecture",      type=str, action="store", default="all", 

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -35,7 +35,7 @@ from . import LibraryIO
 from . import Utils
 from .Common import getArchitectureName, globalParameters, HR, print1, print2, printExit, ensurePath, \
                     CHeader, CMakeHeader, assignGlobalParameters, gfxName, architectureMap, printWarning, \
-                    supportedCompiler
+                    supportedCompiler, which
 from .KernelWriterAssembly import KernelWriterAssembly
 from .KernelWriterSource import KernelWriterSource
 from .SolutionLibrary import MasterSolutionLibrary
@@ -156,23 +156,6 @@ def getAssemblyCodeObjectFiles(kernels, kernelWriterAssembly, outputPath):
         coFiles += newCOFiles
 
     return coFiles
-
-def which(p):
-    """Need to add documentation and likely testing
-    """
-    if os.name == "nt":
-        exes = [p+x for x in ['.bat', '', '.exe']]  # bat may be front end for file with no extension
-    else:
-        exes = [p+x for x in ['', '.exe', '.bat']]
-    system_path = os.environ['PATH'].split(os.pathsep)
-    if supportedCompiler(p) and 'CMAKE_CXX_COMPILER' in os.environ and os.path.isfile(os.environ['CMAKE_CXX_COMPILER']):
-        return os.environ['CMAKE_CXX_COMPILER']
-    for dirname in system_path+[globalParameters["ROCmBinPath"]]:
-        for exe in exes:
-            candidate = os.path.join(os.path.expanduser(dirname), exe)
-            if os.path.isfile(candidate):
-                return candidate
-    return None
 
 def splitArchs():
   # Helper for architecture
@@ -1159,7 +1142,7 @@ def TensileCreateLibrary():
   compilerChoices = ['amdclang++', "hipcc"] if os.name != "nt" else ["clang++", "hipcc"]
   argParser.add_argument("--cxx-compiler", dest="CxxCompiler", choices=compilerChoices, action="store", default=compilerChoices[0],
                          help="C++ compiler used when generating binaries."
-                         " On linux, amdclang++ or hipcc. On Windows clang++ or hipcc.")
+                         " On linux, amdclang++ (default) or hipcc. On Windows clang++ (default) or hipcc.")
   
   argParser.add_argument("--cmake-cxx-compiler",     dest="CmakeCxxCompiler",  action="store")
   argParser.add_argument("--code-object-version",    dest="CodeObjectVersion", choices=["default", "V4", "V5"], action="store")

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -1121,7 +1121,8 @@ def TensileCreateLibrary():
   argParser.add_argument("LogicPath",       help="Path to LibraryLogic.yaml files.")
   argParser.add_argument("OutputPath",      help="Where to write library files?")
   argParser.add_argument("RuntimeLanguage", help="Which runtime language?", choices=["OCL", "HIP", "HSA"])
-  argParser.add_argument("--cxx-compiler",           dest="CxxCompiler",       choices=['amdclang++', "clang++", "hipcc"],       action="store", default="amdclang++")
+  argParser.add_argument("--cxx-compiler",           dest="CxxCompiler",       choices=['amdclang++', "clang++", "hipcc"], action="store", 
+                         default="amdclang++" if os.name != "nt" else "clang++")
   argParser.add_argument("--cmake-cxx-compiler",     dest="CmakeCxxCompiler",  action="store")
   argParser.add_argument("--code-object-version",    dest="CodeObjectVersion", choices=["default", "V4", "V5"], action="store")
   argParser.add_argument("--architecture",           dest="Architecture",      type=str, action="store", default="all", 

--- a/docs/src/cli-reference/TensileCreateLibrary.rst
+++ b/docs/src/cli-reference/TensileCreateLibrary.rst
@@ -44,7 +44,7 @@ When invoking *TensileCreateLibrary*, one can provide zero or more options.
     Creates best-solution.ini in the output directory for the library and code object files created (default).
 \-\-code-object-version={default,V4,V5}
     HSA code-object version.
-\-\-cxx-compiler={hipcc}
+\-\-cxx-compiler={amdclang++, hipcc} or on Windows {clang++, hipcc}
     C++ compiler used when generating binaries.
 \-\-embed-library=EMBEDLIBRARY
     Embed (new) library files into static variables. Specify the name of the library.


### PR DESCRIPTION
This PR extends #1920 by using clang++ rather than hipcc on windows when amdclang++ is selected for the c++ compiler.