### PR TITLE
Add generateManifest fxn and testing

### DIFF
--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -41,7 +41,8 @@ from .KernelWriterSource import KernelWriterSource
 from .SolutionLibrary import MasterSolutionLibrary
 from .SolutionStructs import Solution
 from .Utilities.String import splitDelimitedString
-from .Utilities.toFile import profile, toFile
+from .Utilities.Profile import profile
+from .Utilities.toFile import toFile
 
 import argparse
 import collections

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -1131,6 +1131,22 @@ def createClientConfig(outputPath: Path, masterFile: Path, codeObjectFiles: List
       
       param("best-solution", True)
 
+
+def generateManifest(manifestFile: Path, contents: List[str]) -> None:
+    """Generates tensile manifest.
+
+    Generates a manifest containing all of the tensile outputs including library metadata 
+    code object files, and sources for embedding.
+    
+    Args: 
+        manifestFile: Path to file for writting manifest.
+        contents: List of items to write manifest.
+    """
+    with open(manifestFile, "w") as generatedFile:  
+      for filePath in contents:
+        generatedFile.write(f"{filePath}\n")
+
+
 ################################################################################
 # Tensile Create Library
 ################################################################################
@@ -1153,7 +1169,8 @@ def TensileCreateLibrary():
   argParser.add_argument("LogicPath",       help="Path to LibraryLogic.yaml files.")
   argParser.add_argument("OutputPath",      help="Where to write library files?")
   argParser.add_argument("RuntimeLanguage", help="Which runtime language?", choices=["OCL", "HIP", "HSA"])
-  argParser.add_argument("--cxx-compiler",           dest="CxxCompiler",       choices=["hipcc", 'amdclang++'],       action="store", default="amdclang++")
+  argParser.add_argument("--cxx-compiler",           dest="CxxCompiler",       choices=["hipcc", 'amdclang++'], action="store", 
+                         default="amdclang++" if os.name != "nt" else "clang++")
   argParser.add_argument("--cmake-cxx-compiler",     dest="CmakeCxxCompiler",  action="store")
   argParser.add_argument("--code-object-version",    dest="CodeObjectVersion", choices=["default", "V4", "V5"], action="store")
   argParser.add_argument("--architecture",           dest="Architecture",      type=str, action="store", default="all", 
@@ -1323,13 +1340,8 @@ def TensileCreateLibrary():
    libMetadataPaths) = buildObjectFilePaths(outputPath, solutionFiles, sourceKernelFiles, \
     asmKernelFiles, sourceLibFiles, asmLibFiles, masterLibraries)
 
-  # Manifest file contains YAML file, output library paths and cpp source for embedding.
-  with open(manifestFile, "w") as generatedFile:  
-    for filePath in libMetadataPaths + sourceLibPaths + asmLibPaths:
-      generatedFile.write("%s\n" %(filePath) )
-
-  if globalParameters["GenerateManifestAndExit"] == True:
-    return
+  generateManifest(Path(manifestFile), libMetadataPaths + sourceLibPaths + asmLibPaths)
+  if globalParameters["GenerateManifestAndExit"]: return
 
   # generate cmake for the source kernels,
   if not arguments["GenerateSourcesAndExit"]:

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -1184,7 +1184,7 @@ def TensileCreateLibrary():
   argParser.add_argument("LogicPath",       help="Path to LibraryLogic.yaml files.")
   argParser.add_argument("OutputPath",      help="Where to write library files?")
   argParser.add_argument("RuntimeLanguage", help="Which runtime language?", choices=["OCL", "HIP", "HSA"])
-  argParser.add_argument("--cxx-compiler",           dest="CxxCompiler",       choices=["hipcc", 'amdclang++'],       action="store", default="amdclang++")                         
+  argParser.add_argument("--cxx-compiler",           dest="CxxCompiler",       choices=["hipcc", 'amdclang++'],       action="store", default="amdclang++")
   argParser.add_argument("--cmake-cxx-compiler",     dest="CmakeCxxCompiler",  action="store")
   argParser.add_argument("--code-object-version",    dest="CodeObjectVersion", choices=["default", "V4", "V5"], action="store")
   argParser.add_argument("--architecture",           dest="Architecture",      type=str, action="store", default="all", 

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -41,6 +41,7 @@ from .KernelWriterSource import KernelWriterSource
 from .SolutionLibrary import MasterSolutionLibrary
 from .SolutionStructs import Solution
 from .Utilities.String import splitDelimitedString
+from .Utilities.toFile import toFile
 
 import argparse
 import collections
@@ -1132,21 +1133,6 @@ def createClientConfig(outputPath: Path, masterFile: Path, codeObjectFiles: List
       param("best-solution", True)
 
 
-def generateManifest(manifestFile: Path, contents: List[str]) -> None:
-    """Generates tensile manifest.
-
-    Generates a manifest containing all of the tensile outputs including library metadata 
-    code object files, and sources for embedding.
-    
-    Args: 
-        manifestFile: Path to file for writting manifest.
-        contents: List of items to write manifest.
-    """
-    with open(manifestFile, "w") as generatedFile:  
-      for filePath in contents:
-        generatedFile.write(f"{filePath}\n")
-
-
 ################################################################################
 # Tensile Create Library
 ################################################################################
@@ -1169,8 +1155,7 @@ def TensileCreateLibrary():
   argParser.add_argument("LogicPath",       help="Path to LibraryLogic.yaml files.")
   argParser.add_argument("OutputPath",      help="Where to write library files?")
   argParser.add_argument("RuntimeLanguage", help="Which runtime language?", choices=["OCL", "HIP", "HSA"])
-  argParser.add_argument("--cxx-compiler",           dest="CxxCompiler",       choices=["hipcc", 'amdclang++'], action="store", 
-                         default="amdclang++" if os.name != "nt" else "clang++")
+  argParser.add_argument("--cxx-compiler",           dest="CxxCompiler",       choices=["hipcc", 'amdclang++'],       action="store", default="amdclang++")                         
   argParser.add_argument("--cmake-cxx-compiler",     dest="CmakeCxxCompiler",  action="store")
   argParser.add_argument("--code-object-version",    dest="CodeObjectVersion", choices=["default", "V4", "V5"], action="store")
   argParser.add_argument("--architecture",           dest="Architecture",      type=str, action="store", default="all", 
@@ -1340,7 +1325,7 @@ def TensileCreateLibrary():
    libMetadataPaths) = buildObjectFilePaths(outputPath, solutionFiles, sourceKernelFiles, \
     asmKernelFiles, sourceLibFiles, asmLibFiles, masterLibraries)
 
-  generateManifest(Path(manifestFile), libMetadataPaths + sourceLibPaths + asmLibPaths)
+  toFile(Path(manifestFile), libMetadataPaths + sourceLibPaths + asmLibPaths)
   if globalParameters["GenerateManifestAndExit"]: return
 
   # generate cmake for the source kernels,

--- a/Tensile/Tests/unit/test_TensileCreateLibrary.py
+++ b/Tensile/Tests/unit/test_TensileCreateLibrary.py
@@ -293,27 +293,6 @@ def test_createClientConfig():
 
     cleanClientConfigTest(outputPath, masterLibrary, codeObjectFiles, configFile)
 
-def test_generateManifest():
-    
-    manifest: Path = Path.cwd() / "my-manifest.txt" 
-    metaData = ["metadata.yaml"]
-    codeObjectFiles = ["library/foo.co", "library/bar.co"]
-    sourceCodeObjectFiles = ["library/foo.hsaco", "library/bar.hsaco"]    
-    
-    if manifest.is_file():
-        os.remove(manifest)
-
-    TensileCreateLibrary.generateManifest(manifest, metaData + codeObjectFiles + sourceCodeObjectFiles)        
-
-    assert manifest.is_file(), "{manifest} was not generated"
-    
-    with open(manifest, "r") as f:
-        result = f.readlines()
-        assert len(result) == 5, "Expected five entries in manifest file."
-        
-    if manifest.is_file():
-        os.remove(manifest)        
-
 # ----------------
 # Helper functions
 # ----------------

--- a/Tensile/Tests/unit/test_TensileCreateLibrary.py
+++ b/Tensile/Tests/unit/test_TensileCreateLibrary.py
@@ -293,6 +293,27 @@ def test_createClientConfig():
 
     cleanClientConfigTest(outputPath, masterLibrary, codeObjectFiles, configFile)
 
+def test_generateManifest():
+    
+    manifest: Path = Path.cwd() / "my-manifest.txt" 
+    metaData = ["metadata.yaml"]
+    codeObjectFiles = ["library/foo.co", "library/bar.co"]
+    sourceCodeObjectFiles = ["library/foo.hsaco", "library/bar.hsaco"]    
+    
+    if manifest.is_file():
+        os.remove(manifest)
+
+    TensileCreateLibrary.generateManifest(manifest, metaData + codeObjectFiles + sourceCodeObjectFiles)        
+
+    assert manifest.is_file(), "{manifest} was not generated"
+    
+    with open(manifest, "r") as f:
+        result = f.readlines()
+        assert len(result) == 5, "Expected five entries in manifest file."
+        
+    if manifest.is_file():
+        os.remove(manifest)        
+
 # ----------------
 # Helper functions
 # ----------------

--- a/Tensile/Tests/unit/test_Utilities.py
+++ b/Tensile/Tests/unit/test_Utilities.py
@@ -23,6 +23,9 @@
 ################################################################################
 
 from Tensile.Utilities.String import splitDelimitedString
+from Tensile.Utilities.toFile import toFile
+from pathlib import Path
+import os
 
 def test_splitDelimitedString():
     archs = "all"
@@ -64,3 +67,21 @@ def test_splitDelimitedString():
     expected = {"abc", "gfx90Z", "all"}
     result = splitDelimitedString(archs, {";", "_"})
     assert result == expected, f"arch `{archs}` should map to {expected} but instead maps to {result}"
+
+def test_toFile():
+    
+    manifest: Path = Path.cwd() / "my-manifest.txt"
+
+    sourceCodeObjectFiles = ["library/foo.hsaco", "library/bar.hsaco"]
+    sourceCodeObjectFiles = ["library/foo.hsaco", "library/bar.hsaco"]
+    
+    if manifest.is_file():
+        os.remove(manifest)
+
+    toFile(manifest, metaData + codeObjectFiles + sourceCodeObjectFiles)        
+
+    assert manifest.is_file(), "{manifest} was not generated"
+    assert len(result) == 5, "Expected five entries in manifest file."
+        
+    if manifest.is_file():
+        os.remove(manifest)        

--- a/Tensile/Tests/unit/test_Utilities.py
+++ b/Tensile/Tests/unit/test_Utilities.py
@@ -71,8 +71,8 @@ def test_splitDelimitedString():
 def test_toFile():
     
     manifest: Path = Path.cwd() / "my-manifest.txt"
-
-    sourceCodeObjectFiles = ["library/foo.hsaco", "library/bar.hsaco"]
+    metaData = ["mylib.yaml"]
+    codeObjectFiles = ["library/foo.co", "library/bar.co"]
     sourceCodeObjectFiles = ["library/foo.hsaco", "library/bar.hsaco"]
     
     if manifest.is_file():
@@ -81,6 +81,9 @@ def test_toFile():
     toFile(manifest, metaData + codeObjectFiles + sourceCodeObjectFiles)        
 
     assert manifest.is_file(), "{manifest} was not generated"
+    with open(manifest, "r") as f:
+        result = f.readlines()
+        
     assert len(result) == 5, "Expected five entries in manifest file."
         
     if manifest.is_file():

--- a/Tensile/Tests/unit/test_Utilities.py
+++ b/Tensile/Tests/unit/test_Utilities.py
@@ -25,6 +25,7 @@
 from Tensile.Utilities.String import splitDelimitedString
 from Tensile.Utilities.toFile import toFile
 from pathlib import Path
+import pytest
 import os
 
 def test_splitDelimitedString():
@@ -78,7 +79,13 @@ def test_toFile():
     if manifest.is_file():
         os.remove(manifest)
 
-    toFile(manifest, metaData + codeObjectFiles + sourceCodeObjectFiles)        
+    with pytest.raises(AssertionError, match="contents must be a list."):     
+        toFile(manifest, (1,2,3))        
+
+    with pytest.raises(AssertionError, match="contents elements must be a str."):     
+        toFile(manifest, [1,2,3])        
+
+    toFile(manifest, metaData + codeObjectFiles + sourceCodeObjectFiles)
 
     assert manifest.is_file(), "{manifest} was not generated"
     with open(manifest, "r") as f:

--- a/Tensile/Utilities/toFile.py
+++ b/Tensile/Utilities/toFile.py
@@ -28,13 +28,19 @@ from typing import List
 def toFile(outputFile: Path, contents: List[str], delimiter: str = "\n") -> None:
     """Generates a user specified delimited file. 
 
-    Writes the elements of a List of strings with a given delimiter 
+    Writes the elements of a List of strings with a given delimiter.
     
     Args: 
         outputFile: Path to file for writting manifest.
         contents: List of items to write manifest.
         delimiter: Symbol used to delimit elements when writing file.
+    
+    Raises:
+        ValueError: If contents is not a List[str]
     """
+    assert isinstance(contents, list), f"contents must be a list."
+    assert isinstance(contents[0], str), f"contents elements must be a str."
+
     with open(outputFile, "w") as generatedFile:  
       for filePath in contents:
         generatedFile.write(f"{filePath}{delimiter}")

--- a/Tensile/Utilities/toFile.py
+++ b/Tensile/Utilities/toFile.py
@@ -1,0 +1,41 @@
+################################################################################
+#
+# Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+################################################################################
+
+from pathlib import Path
+from typing import List
+
+def toFile(outputFile: Path, contents: List[str], delimiter: str = "\n") -> None:
+    """Generates a user specified delimited file. 
+
+    Writes the elements of a List of strings with a given delimiter 
+    
+    Args: 
+        outputFile: Path to file for writting manifest.
+        contents: List of items to write manifest.
+        delimiter: Symbol used to delimit elements when writing file.
+    """
+
+    with open(manifestFile, "w") as generatedFile:  
+      for filePath in contents:
+        generatedFile.write(f"{filePath}{delimiter}")

--- a/Tensile/Utilities/toFile.py
+++ b/Tensile/Utilities/toFile.py
@@ -31,7 +31,7 @@ def toFile(outputFile: Path, contents: List[str], delimiter: str = "\n") -> None
     Writes the elements of a List of strings with a given delimiter.
     
     Args: 
-        outputFile: Path to file for writting manifest.
+        outputFile: Path to file for writing manifest.
         contents: List of items to write manifest.
         delimiter: Symbol used to delimit elements when writing file.
     

--- a/Tensile/Utilities/toFile.py
+++ b/Tensile/Utilities/toFile.py
@@ -35,7 +35,6 @@ def toFile(outputFile: Path, contents: List[str], delimiter: str = "\n") -> None
         contents: List of items to write manifest.
         delimiter: Symbol used to delimit elements when writing file.
     """
-
-    with open(manifestFile, "w") as generatedFile:  
+    with open(outputFile, "w") as generatedFile:  
       for filePath in contents:
         generatedFile.write(f"{filePath}{delimiter}")

--- a/Tensile/Utilities/toFile.py
+++ b/Tensile/Utilities/toFile.py
@@ -38,8 +38,8 @@ def toFile(outputFile: Path, contents: List[str], delimiter: str = "\n") -> None
     Raises:
         AssertionError: If contents is not a List[str]
     """
-    assert isinstance(contents, list), f"contents must be a list."
-    assert isinstance(contents[0], str), f"contents elements must be a str."
+    assert isinstance(contents, list), "contents must be a list."
+    assert isinstance(contents[0], str), "contents elements must be a str."
 
     with open(outputFile, "w") as generatedFile:  
       for filePath in contents:

--- a/Tensile/Utilities/toFile.py
+++ b/Tensile/Utilities/toFile.py
@@ -36,7 +36,7 @@ def toFile(outputFile: Path, contents: List[str], delimiter: str = "\n") -> None
         delimiter: Symbol used to delimit elements when writing file.
     
     Raises:
-        ValueError: If contents is not a List[str]
+        AssertionError: If contents is not a List[str]
     """
     assert isinstance(contents, list), f"contents must be a list."
     assert isinstance(contents[0], str), f"contents elements must be a str."

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -14,6 +14,7 @@ subtrees:
       entries:
         - file: src/api-reference/Common
         - file: src/api-reference/TensileCreateLibrary
+        - file: src/api-reference/Utilities        
     - file: src/cli-reference
       entries: 
         - file: src/cli-reference/TensileCreateLibrary                    

--- a/docs/src/api-reference/TensileCreateLibrary.rst
+++ b/docs/src/api-reference/TensileCreateLibrary.rst
@@ -5,6 +5,7 @@
 TensileCreateLibrary
 ====================
 
-.. autofunction:: Tensile.TensileCreateLibrary::createClientConfig    
+.. autofunction:: Tensile.TensileCreateLibrary::createClientConfig
 .. autofunction:: Tensile.TensileCreateLibrary::findLogicFiles
+.. autofunction:: Tensile.TensileCreateLibrary::generateManifest
 .. autofunction:: Tensile.TensileCreateLibrary::verifyManifest

--- a/docs/src/api-reference/TensileCreateLibrary.rst
+++ b/docs/src/api-reference/TensileCreateLibrary.rst
@@ -7,11 +7,6 @@ TensileCreateLibrary
 
 .. autofunction:: Tensile.TensileCreateLibrary::createClientConfig
 .. autofunction:: Tensile.TensileCreateLibrary::findLogicFiles
-<<<<<<< HEAD
-.. autofunction:: Tensile.TensileCreateLibrary::generateManifest
-.. autofunction:: Tensile.TensileCreateLibrary::verifyManifest
-=======
 .. autofunction:: Tensile.TensileCreateLibrary::sanityCheck
 .. autofunction:: Tensile.TensileCreateLibrary::verifyManifest
 
->>>>>>> origin-s/develop

--- a/docs/src/api-reference/Utilities.rst
+++ b/docs/src/api-reference/Utilities.rst
@@ -1,0 +1,8 @@
+
+.. _utitilities-api-reference:
+
+=========
+Utilities
+=========
+
+.. autofunction:: Tensile.Utilities.toFile::toFile

--- a/docs/src/api-reference/Utilities.rst
+++ b/docs/src/api-reference/Utilities.rst
@@ -5,4 +5,6 @@
 Utilities
 =========
 
+.. autofunction:: Tensile.Utilities.Profile::profile
+.. autofunction:: Tensile.Utilities.String::splitDelimitedString
 .. autofunction:: Tensile.Utilities.toFile::toFile


### PR DESCRIPTION
This PR factors the logic from TensileCreateLibrary associated with generating a tensile binary artifact manifest into a function called `generateManifest`. The goal of this work is to enable testing, documentation and profiling of the corresponding code.