### PR TITLE
Add functions for writing master files 

### DIFF
--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -1139,7 +1139,7 @@ def generateMasterFileList(masterLibraries: dict, archs: List[str], lazy: bool) 
     result = [(baseName + arch, masterLibrary) for arch, masterLibrary in masterLibraries.items() if arch in archs]
     return generateLazyMasterFileList(result) if lazy else result
 
-def writeMasterFile(libraryPath: Path, name: str, lib: MasterSolutionLibrary, format: str, naming: dict):
+def writeMasterFile(libraryPath: Path, format: str, naming: dict, name: str, lib: MasterSolutionLibrary):
     """ Writes a master file to disk as a .yaml or .dat file.
 
     Args:
@@ -1367,10 +1367,12 @@ def TensileCreateLibrary():
              if globalParameters["AsmCaps"][arch]["SupportedISA"]]
 
   newLibraryDir = Path(outputPath) / "library"
+  newLibraryDir.mkdir(exist_ok=True)
 
   masterFileList = generateMasterFileList(masterLibraries, archs, args.LazyLibraryLoading) if args.SeparateArchitectures \
     else [("TensileLibrary", fullMasterLibrary)]
-  map(partial(writeMasterFile, outputPath=newLibraryDir, format=args.LibraryFormat, naming=kernelMinNaming), masterFileList)
+  for name, lib in masterFileList:
+    writeMasterFile(newLibraryDir, args.LibraryFormat, kernelMinNaming, name, lib)
   masterFile, fullMasterLibrary = masterFileList[0]
   
   ext = ".yaml" if globalParameters["LibraryFormat"] == "yaml" else ".dat"

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -1110,11 +1110,11 @@ def generateClientConfig(outputPath: Path, masterFile: Path, codeObjectFiles: Li
       param("best-solution", True)
 
 def generateLazyMasterFileList(masterFileList: List[Tuple[str, MasterSolutionLibrary]]) -> List[Tuple[str, MasterSolutionLibrary]]:
-    """ Generates a list of tuples that represent the name and the state associated the lazy master libraries.
+    """ Generates a list of tuples that represent the name and the state associated with the lazy master libraries.
 
-    This function takes a list of MasterSolutionLibraries and traverses its lazy libraries.
+    This function takes a list of MasterSolutionLibraries and traverses each lazy libraries.
     It collects the items (i.e. the name and corresponding master file) and adds them to list
-    of master files to be written to disk.
+    of master files.
 
     Args:
         masterLibraries: A list of name / master solution library pairs.
@@ -1122,17 +1122,17 @@ def generateLazyMasterFileList(masterFileList: List[Tuple[str, MasterSolutionLib
     return masterFileList + list(itertools.chain.from_iterable((t for t in lib.lazyLibraries.items()) for _, lib in masterFileList))
 
 def generateMasterFileList(masterLibraries: dict, archs: List[str], lazy: bool) -> List[Tuple[str, MasterSolutionLibrary]]:
-    """ Generates a list of tuples that represent the name and the state associated the architecture
+    """ Generates a list of tuples that represent the name and the state associated with the architecture
         specific master libraries.
 
     This function takes a dictionary with keys corresponding to a target architecture and values 
-    corresponding to the master solution library for that architecture. The fucntion generates
+    corresponding to the master solution library for that architecture. The function generates a
     tuple consisting of a MasterSolutionLibrary and the associated name.
 
     Args:
         masterLibraries: A dictionary of architecture name / master solution library pairs.
         archs: A list of supported architectures.
-        lazy: If True, add lazy library masterFiles.
+        lazy: If True, add lazy library master files.
     """
     baseName = "TensileLibrary_lazy_" if lazy else "TensileLibrary_"
     result = [(baseName + arch, masterLibrary) for arch, masterLibrary in masterLibraries.items() if arch in archs]
@@ -1143,10 +1143,10 @@ def writeMasterFile(libraryPath: Path, format: str, naming: dict, name: str, lib
 
     Args:
         libraryPath: Path to library subdirectory located in the tensile output directory.
-        name: Name of the masterfile.
-        lib: Master solution library data.
         format: Output format of written file (.dat or .yaml).
         naming: Kernel minimum naming.
+        name: Name of the masterfile.
+        lib: Master solution library data.
     """
     lib.applyNaming(naming)
     LibraryIO.write(str(libraryPath / name), Utils.state(lib), format)

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -1118,8 +1118,11 @@ def generateLazyMasterFileList(masterFileList: List[Tuple[str, MasterSolutionLib
 
     Args:
         masterLibraries: A list of name / master solution library pairs.
+
+    Returns:
+        List of pairs of master solutions libraries and the corresponding name.
     """
-    return masterFileList + list(itertools.chain.from_iterable((t for t in lib.lazyLibraries.items()) for _, lib in masterFileList))
+    return list(itertools.chain.from_iterable((t for t in lib.lazyLibraries.items()) for _, lib in masterFileList))
 
 def generateMasterFileList(masterLibraries: dict, archs: List[str], lazy: bool) -> List[Tuple[str, MasterSolutionLibrary]]:
     """ Generates a list of tuples that represent the name and the state associated with the architecture
@@ -1133,12 +1136,15 @@ def generateMasterFileList(masterLibraries: dict, archs: List[str], lazy: bool) 
         masterLibraries: A dictionary of architecture name / master solution library pairs.
         archs: A list of supported architectures.
         lazy: If True, add lazy library master files.
+
+    Returns:
+        List of pairs of master solutions libraries and the corresponding name.        
     """
     baseName = "TensileLibrary_lazy_" if lazy else "TensileLibrary_"
     result = [(baseName + arch, masterLibrary) for arch, masterLibrary in masterLibraries.items() if arch in archs]
-    return generateLazyMasterFileList(result) if lazy else result
+    return result + generateLazyMasterFileList(result) if lazy else result
 
-def writeMasterFile(libraryPath: Path, format: str, naming: dict, name: str, lib: MasterSolutionLibrary):
+def writeMasterFile(libraryPath: Path, format: str, naming: dict, name: str, lib: MasterSolutionLibrary) -> None:
     """ Writes a master file to disk as a .yaml or .dat file.
 
     Args:

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -57,8 +57,9 @@ import time
 import warnings
 
 from copy import deepcopy
-from typing import Set, List
+from typing import Set, List, Tuple
 from pathlib import Path
+from functools import partial
 
 TENSILE_MANIFEST_FILENAME = "TensileManifest.txt"
 TENSILE_LIBRARY_DIR = "library"
@@ -1078,7 +1079,7 @@ def sanityCheck(srcLibPaths: List[str], asmLibPaths: List[str], codeObjectPaths:
             raise ValueError(f"Sanity check failed; missing expected code object files: "\
                     f"{[p.name for p  in extraLibs]}")
 
-def createClientConfig(outputPath: Path, masterFile: Path, codeObjectFiles: List[str], configFile: str = "best-solution.ini") -> None:
+def generateClientConfig(outputPath: Path, masterFile: Path, codeObjectFiles: List[str], configFile: str = "best-solution.ini") -> None:
     """Generates a client config file.
     
     Generates a client config file corresponding to a master library file and code-object parameters
@@ -1109,6 +1110,47 @@ def createClientConfig(outputPath: Path, masterFile: Path, codeObjectFiles: List
       
       param("best-solution", True)
 
+def generateLazyMasterFileList(masterFileList: List[Tuple[str, MasterSolutionLibrary]]) -> List[Tuple[str, MasterSolutionLibrary]]:
+    """ Generates a list of tuples that represent the name and the state associated the lazy master libraries.
+
+    This function takes a list of MasterSolutionLibraries and traverses its lazy libraries.
+    It collects the items (i.e. the name and corresponding master file) and adds them to list
+    of master files to be written to disk.
+
+    Args:
+        masterLibraries: A list of name / master solution library pairs.
+    """
+    return masterFileList + list(itertools.chain.from_iterable((t for t in lib.lazyLibraries.items()) for _, lib in masterFileList))
+
+def generateMasterFileList(masterLibraries: dict, archs: List[str], lazy: bool) -> List[Tuple[str, MasterSolutionLibrary]]:
+    """ Generates a list of tuples that represent the name and the state associated the architecture
+        specific master libraries.
+
+    This function takes a dictionary with keys corresponding to a target architecture and values 
+    corresponding to the master solution library for that architecture. The fucntion generates
+    tuple consisting of a MasterSolutionLibrary and the associated name.
+
+    Args:
+        masterLibraries: A dictionary of architecture name / master solution library pairs.
+        archs: A list of supported architectures.
+        lazy: If True, add lazy library masterFiles.
+    """
+    baseName = "TensileLibrary_lazy_" if lazy else "TensileLibrary_"
+    result = [(baseName + arch, masterLibrary) for arch, masterLibrary in masterLibraries.items() if arch in archs]
+    return generateLazyMasterFileList(result) if lazy else result
+
+def writeMasterFile(libraryPath: Path, name: str, lib: MasterSolutionLibrary, format: str, naming: dict):
+    """ Writes a master file to disk as a .yaml or .dat file.
+
+    Args:
+        libraryPath: Path to library subdirectory located in the tensile output directory.
+        name: Name of the masterfile.
+        lib: Master solution library data.
+        format: Output format of written file (.dat or .yaml).
+        naming: Kernel minimum naming.
+    """
+    lib.applyNaming(naming)
+    LibraryIO.write(str(libraryPath / name), Utils.state(lib), format)
 
 ################################################################################
 # Tensile Create Library
@@ -1320,46 +1362,28 @@ def TensileCreateLibrary():
       print1(f"codeObjectFiles: {codeObjectFiles}")
       print1(f"sourceLibPaths + asmLibPaths: {sourceLibPaths + asmLibPaths}")
 
+  # do we need this or have we already done this?
   archs = [gfxName(arch) for arch in globalParameters['SupportedISA'] \
              if globalParameters["AsmCaps"][arch]["SupportedISA"]]
-  newLibraryDir = ensurePath(os.path.join(outputPath, 'library'))
 
-  if globalParameters["SeparateArchitectures"] or globalParameters["LazyLibraryLoading"]:
-    for archName, newMasterLibrary in masterLibraries.items():
-      if archName in archs:
-        if globalParameters["LazyLibraryLoading"]:
-          masterFile = os.path.join(newLibraryDir, "TensileLibrary_lazy_"+archName)
-        else:
-          masterFile = os.path.join(newLibraryDir, "TensileLibrary_"+archName)
-        newMasterLibrary.applyNaming(kernelMinNaming)
-        LibraryIO.write(masterFile, Utils.state(newMasterLibrary), args.LibraryFormat)
+  newLibraryDir = Path(outputPath) / "library"
 
-        #Write placeholder libraries
-        for name, lib in newMasterLibrary.lazyLibraries.items():
-          filename = os.path.join(newLibraryDir, name)
-          lib.applyNaming(kernelMinNaming) #@TODO Check to see if kernelMinNaming is correct
-          LibraryIO.write(filename, Utils.state(lib), args.LibraryFormat)
-
-  else:
-    masterFile = os.path.join(newLibraryDir, "TensileLibrary")
-    fullMasterLibrary.applyNaming(kernelMinNaming)
-    LibraryIO.write(masterFile, Utils.state(fullMasterLibrary), args.LibraryFormat)
-
-  theMasterLibrary = fullMasterLibrary
-  if globalParameters["SeparateArchitectures"]:
-    theMasterLibrary = list(masterLibraries.values())[0]
+  masterFileList = generateMasterFileList(masterLibraries, archs, args.LazyLibraryLoading) if args.SeparateArchitectures \
+    else [("TensileLibrary", fullMasterLibrary)]
+  map(partial(writeMasterFile, outputPath=newLibraryDir, format=args.LibraryFormat, naming=kernelMinNaming), masterFileList)
+  masterFile, fullMasterLibrary = masterFileList[0]
   
   ext = ".yaml" if globalParameters["LibraryFormat"] == "yaml" else ".dat"
   if args.EmbedLibrary:
     embedFileName = Path(outputPath) / "library" / args.EmbedLibrary
-    EmbeddedData.generateLibrary(embedFileName, args.EmbedLibraryKey, Path(masterFile).with_suffix(ext), theMasterLibrary.cpp_base_class, codeObjectFiles)
+    EmbeddedData.generateLibrary(embedFileName, args.EmbedLibraryKey, (newLibraryDir / masterFile).with_suffix(ext), fullMasterLibrary.cpp_base_class, codeObjectFiles)
 
   if args.BuildClient:
     print1("# Building Tensile Client")
     ClientExecutable.getClientExecutable(outputPath)
 
   if args.ClientConfig:
-    createClientConfig(Path(outputPath), Path(masterFile).with_suffix(ext), codeObjectFiles)
+    generateClientConfig(Path(outputPath), Path(masterFile).with_suffix(ext), codeObjectFiles)
 
   print1("# Tensile Library Writer DONE")
   print1(HR)

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -1122,7 +1122,7 @@ def generateLazyMasterFileList(masterFileList: List[Tuple[str, MasterSolutionLib
     Returns:
         List of pairs of master solutions libraries and the corresponding name.
     """
-    return list(itertools.chain.from_iterable((t for t in lib.lazyLibraries.items()) for _, lib in masterFileList))
+    return [t for _, lib in masterFileList for t in lib.lazyLibraries.items()]
 
 def generateMasterFileList(masterLibraries: dict, archs: List[str], lazy: bool) -> List[Tuple[str, MasterSolutionLibrary]]:
     """ Generates a list of tuples that represent the name and the state associated with the architecture

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -59,7 +59,6 @@ import warnings
 from copy import deepcopy
 from typing import Set, List, Tuple
 from pathlib import Path
-from functools import partial
 
 TENSILE_MANIFEST_FILENAME = "TensileManifest.txt"
 TENSILE_LIBRARY_DIR = "library"

--- a/Tensile/Tests/unit/test_TensileCreateLibrary.py
+++ b/Tensile/Tests/unit/test_TensileCreateLibrary.py
@@ -310,7 +310,7 @@ def test_generateClientConfig():
 
     setupClientConfigTest(outputPath, masterLibrary, codeObjectFiles)
 
-    TensileCreateLibrary.generateClientConfigClientConfig(outputPath, masterLibrary, codeObjectFiles)
+    TensileCreateLibrary.generateClientConfig(outputPath, masterLibrary, codeObjectFiles)
 
     assert configFile.is_file(), "{configFile} was not generated"
     
@@ -322,9 +322,6 @@ def test_generateClientConfig():
         assert "best-solution" in result[3], "missing best-solution entry"                
 
     cleanClientConfigTest(outputPath, masterLibrary, codeObjectFiles, configFile)
-
-# masterLibraryListSA = ((baseName + arch, masterLibrary) for arch, masterLibrary in masterLibraries.items() if arch in archs)
-# masterLibraryListLazy = ((t for t in lib.lazyLibraries.items()) for lib in masterLibraryListSA)
 
 class MasterLibraryMock:
     def __init__(self, libraries, data):

--- a/Tensile/Tests/unit/test_TensileCreateLibrary.py
+++ b/Tensile/Tests/unit/test_TensileCreateLibrary.py
@@ -296,7 +296,7 @@ def test_sanityCheck():
         except:
             raise Exception
 
-def test_createClientConfig():
+def test_generateClientConfig():
     
     outputPath: Path = Path.cwd() / "my-output"
     masterLibrary: Path = outputPath / "masterlib.data" 
@@ -306,11 +306,11 @@ def test_createClientConfig():
     cleanClientConfigTest(outputPath, masterLibrary, codeObjectFiles, configFile)
 
     with pytest.raises(FileNotFoundError, match=r"(.*) No such file or directory: '(.*)/my-output/best-solution.ini'"): 
-        TensileCreateLibrary.createClientConfig(outputPath, masterLibrary, codeObjectFiles)        
+        TensileCreateLibrary.generateClientConfig(outputPath, masterLibrary, codeObjectFiles)        
 
     setupClientConfigTest(outputPath, masterLibrary, codeObjectFiles)
 
-    TensileCreateLibrary.createClientConfig(outputPath, masterLibrary, codeObjectFiles)
+    TensileCreateLibrary.generateClientConfigClientConfig(outputPath, masterLibrary, codeObjectFiles)
 
     assert configFile.is_file(), "{configFile} was not generated"
     
@@ -322,6 +322,38 @@ def test_createClientConfig():
         assert "best-solution" in result[3], "missing best-solution entry"                
 
     cleanClientConfigTest(outputPath, masterLibrary, codeObjectFiles, configFile)
+
+# masterLibraryListSA = ((baseName + arch, masterLibrary) for arch, masterLibrary in masterLibraries.items() if arch in archs)
+# masterLibraryListLazy = ((t for t in lib.lazyLibraries.items()) for lib in masterLibraryListSA)
+
+class MasterLibraryMock:
+    def __init__(self, libraries, data):
+        self.lazyLibraries = libraries
+        self.data = data
+
+def test_generateMasterFileList():
+  
+  archs = ["arch0", "arch1"]  
+  libraries = {"arch0" : MasterLibraryMock({"mylib0" : MasterLibraryMock(None, 2)}, 0),
+               "arch1" : MasterLibraryMock({"mylib1" : MasterLibraryMock(None, 3)}, 1)}
+
+  result = TensileCreateLibrary.generateMasterFileList(libraries, archs, lazy=False)
+  for idx, t in enumerate(result):
+    assert t[0] == "TensileLibrary_arch" + str(idx), "Incorrect naming for key."
+    assert isinstance(t[1], MasterLibraryMock), "Incorrect type for value."
+    assert t[1].data == idx, "Incorrect data."    
+  
+  result = TensileCreateLibrary.generateMasterFileList(libraries, archs, lazy=True)
+
+  for idx, t in enumerate(result[0:2]):
+    assert t[0] == "TensileLibrary_lazy_arch" + str(idx), "Incorrect naming for key."
+    assert isinstance(t[1], MasterLibraryMock), "Incorrect type for value."
+    assert t[1].data == idx, "Incorrect data."    
+
+  for idx, t in enumerate(result[2:4]):
+    assert t[0] == "mylib" + str(idx), "Incorrect naming for key."
+    assert isinstance(t[1], MasterLibraryMock), "Incorrect type for value."
+    assert t[1].data == (idx+2), "Incorrect data."        
 
 # ----------------
 # Helper functions

--- a/docs/src/api-reference/TensileCreateLibrary.rst
+++ b/docs/src/api-reference/TensileCreateLibrary.rst
@@ -5,8 +5,10 @@
 TensileCreateLibrary
 ====================
 
-.. autofunction:: Tensile.TensileCreateLibrary::createClientConfig
 .. autofunction:: Tensile.TensileCreateLibrary::findLogicFiles
+.. autofunction:: Tensile.TensileCreateLibrary::generateClientConfig
+.. autofunction:: Tensile.TensileCreateLibrary::generateMasterFileList
+.. autofunction:: Tensile.TensileCreateLibrary::generateMasterFileList
 .. autofunction:: Tensile.TensileCreateLibrary::sanityCheck
 .. autofunction:: Tensile.TensileCreateLibrary::verifyManifest
-
+.. autofunction:: Tensile.TensileCreateLibrary::writeMasterFile


### PR DESCRIPTION
This PR factors out logic from TensileCreateLibrary related to writing master files to disk into functions that are testable, profitable and documented. 