### PR TITLE
Disable failing rhel9 tests

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -117,7 +117,8 @@ def runTestCommand(platform, project, jobName, testMark, boolean runHostTest=tru
         """
     platform.runCommand(this, command)
 
-    archiveArtifacts "${project.paths.project_build_prefix}/timing*.csv"
+    if (platform.os != "rhel9")        
+        archiveArtifacts "${project.paths.project_build_prefix}/timing*.csv"
     if (runUnitTest) {
         recordCoverage(tools: [[parser: 'COBERTURA', pattern: "${project.paths.project_build_prefix}/cobertura.xml"]])
     }

--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -102,7 +102,7 @@ def runTestCommand(platform, project, jobName, testMark, boolean runHostTest=tru
               check_err
             fi
             echo The operating system is ${platform.os}
-            if [ ${platform.os} != "rhel9" ]
+            if [ ${platform.os} != "rhel9" ]; then
               tox --version
               tox run -e ci -- -m ${testMark} --timing-file=\$TIMING_FILE
               check_err

--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -97,21 +97,23 @@ def runTestCommand(platform, project, jobName, testMark, boolean runHostTest=tru
             export GPU_ARCH=`/opt/rocm/bin/rocm_agent_enumerator  | tail -n 1`
             export TIMING_FILE=`pwd`/timing-\$GPU_ARCH.csv
 
-            tox --version
-            tox run -e ci -- -m ${testMark} --timing-file=\$TIMING_FILE
-            check_err
-
             if ${runUnitTest}; then 
               tox run -e unittest -- --cov-report=xml:cobertura.xml
               check_err
             fi
-
-            if ${runHostTest}; then
-              pushd build
-              ./TensileTests ${markSkipExtendedTest} --gtest_color=yes
+            echo The operating system is ${platform.os}
+            if [ ${platform.os} != "rhel9" ]
+              tox --version
+              tox run -e ci -- -m ${testMark} --timing-file=\$TIMING_FILE
               check_err
-              popd
-            fi
+  
+              if ${runHostTest}; then
+                pushd build
+                ./TensileTests ${markSkipExtendedTest} --gtest_color=yes
+                check_err
+                popd
+              fi
+            fi  
         """
     platform.runCommand(this, command)
 

--- a/.jenkins/precheckin.groovy
+++ b/.jenkins/precheckin.groovy
@@ -55,9 +55,11 @@ def runCI =
         platform, project->
 
         commonGroovy = load "${project.paths.project_src_prefix}/.jenkins/common.groovy"
-        commonGroovy.runCompileCommand(platform, project, jobName, false)
+        if (platform.os != "rhel9")        
+            commonGroovy.runCompileCommand(platform, project, jobName, false)
     }
 
+    
     def testCommand =
     {
         platform, project->


### PR DESCRIPTION
The rhel9 tests are failing on develop post-merge due to a link error when building the client via:

```
tox  run -e ci -- -m unit
```

and also when building the HostLibraryTests. Here we temporarily disable this testing for rhel9 until a permanent fix is identified.