### PR TITLE
Restrict XCC mapping to gfx942

### DIFF
--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -2982,6 +2982,9 @@ class Solution(collections.abc.Mapping):
         reject(state, "Cannot enable both Stream-K and PersistentKernel")
       if not state["ProblemType"]["StridedBatched"]:
         reject(state, "General batch not supported with Stream-K")
+      if state["StreamKXCCMapping"] > 0:
+        if isa != [9,4,2]:
+          reject(state, "XCC mapping currently only on gfx942")
       if state["StreamKAtomic"] == 1:
         if not state["ProblemType"]["DataType"].isSingle():
           reject(state, "Atomic Stream-K currently only tested for SGEMM")

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -2983,7 +2983,7 @@ class Solution(collections.abc.Mapping):
       if not state["ProblemType"]["StridedBatched"]:
         reject(state, "General batch not supported with Stream-K")
       if state["StreamKXCCMapping"] > 0:
-        if isa != [9,4,2]:
+        if isa != (9,4,2):
           reject(state, "XCC mapping currently only on gfx942")
       if state["StreamKAtomic"] == 1:
         if not state["ProblemType"]["DataType"].isSingle():


### PR DESCRIPTION
The feature currently only applies to gfx942 and is untested on older architectures. Add reject case for other architectures for now until the feature is fully tested on those devices.