### PR TITLE
Filter kernels with build errors

### DIFF
--- a/.jenkins/staticanalysis.groovy
+++ b/.jenkins/staticanalysis.groovy
@@ -55,6 +55,7 @@ def runCompileCommand(platform, project, jobName, boolean debug=false)
             tox --version
             tox run -v --workdir /tmp/.tensile-tox -e lint
             tox run -v -e format -- --check
+            tox run -v -e isort -- --check
 
             doxygen docs/doxygen/Doxyfile
             """

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -1991,7 +1991,7 @@ def printWarning(message: str, category: type[Warning]=DeveloperWarning):
   sys.stdout.flush()
 
 def printExit(message):
-  print("Tensile::FATAL: %s" % message)
+  rich.print(f"[bold red]Fatal: {message}[/bold red]")
   sys.stdout.flush()
   sys.exit(-1)
 

--- a/Tensile/TensileCreateLib/ParseArguments.py
+++ b/Tensile/TensileCreateLib/ParseArguments.py
@@ -27,7 +27,7 @@ import warnings
 from argparse import Action, ArgumentParser
 from typing import Any, Dict, List, Optional
 
-from ..Common import architectureMap, DeveloperWarning
+from ..Common import DeveloperWarning, architectureMap
 
 
 class DeprecatedOption(Action):

--- a/Tensile/TensileCreateLib/ParseArguments.py
+++ b/Tensile/TensileCreateLib/ParseArguments.py
@@ -24,9 +24,8 @@
 
 import os
 import warnings
-
-from typing import Dict, Any, List
-from argparse import ArgumentParser, Action
+from argparse import Action, ArgumentParser
+from typing import Any, Dict
 
 from ..Common import architectureMap
 

--- a/Tensile/TensileCreateLib/ParseArguments.py
+++ b/Tensile/TensileCreateLib/ParseArguments.py
@@ -25,7 +25,7 @@
 import os
 import warnings
 from argparse import Action, ArgumentParser
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from ..Common import architectureMap
 

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -45,10 +45,21 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Set, Tuple
 
 from . import ClientExecutable, Common, EmbeddedData, LibraryIO, Utils
-from .Common import (HR, CHeader, CMakeHeader, assignGlobalParameters,
-                     ensurePath, getArchitectureName, gfxName,
-                     globalParameters, printExit, printWarning,
-                     supportedCompiler, tPrint, which)
+from .Common import (
+    HR,
+    CHeader,
+    CMakeHeader,
+    assignGlobalParameters,
+    ensurePath,
+    getArchitectureName,
+    gfxName,
+    globalParameters,
+    printExit,
+    printWarning,
+    supportedCompiler,
+    tPrint,
+    which,
+)
 from .KernelWriterAssembly import KernelWriterAssembly
 from .KernelWriterBase import KernelWriterBase
 from .KernelWriterSource import KernelWriterSource

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -633,8 +633,7 @@ def filterBuildErrors(
     writerSelectionFn: Callable[[str], KernelWriterSource | KernelWriterAssembly],
     ignoreErr: bool,
 ):
-    """
-    Filters a list of kernels based on build errors and error tolerance.
+    """Filters a list of kernels based on build errors and error tolerance.
 
     Args:
         kernels: A list of `Solution` objects representing kernels to filter.
@@ -645,7 +644,7 @@ def filterBuildErrors(
         A filtered list of kernels (**Solution** objects) that are eligible for building.
 
     Raises:
-        SystemExit: If **error_tolerant** is False and any kernels have build errors.
+        SystemExit: If **ignoreErr** is False and any kernels have build errors.
     """
     if not ignoreErr and len(kernelsWithBuildErrors) > 0:
         printExit(

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -723,8 +723,6 @@ def writeKernels(
 
     kernelFiles, kernelsWithBuildErrors = buildKernelSourceAndHeaderFiles(results, outputPath)
 
-    ## TODO(bstefanuk): I'm not convinced this is returning distinct output above just calling the base class function
-    ## KernelWriter.getKernelName(...)
     writerSelector = lambda lang: kernelWriterAssembly if lang == "Assembly" else kernelWriterSource
     kernelsToBuild = filterBuildErrors(
         kernels, kernelsWithBuildErrors, writerSelector, errorTolerant

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -69,7 +69,7 @@ def processKernelSource(kernel, kernelWriterSource, kernelWriterAssembly):
     Returns (error, source, header, kernelName).
     """
     try:
-        kernelWriter = (
+        kernelWriter: KernelWriterAssembly | KernelWriterSource = (
             kernelWriterSource if kernel["KernelLanguage"] == "Source" else kernelWriterAssembly
         )
         # get kernel name
@@ -542,7 +542,7 @@ def buildKernelSourceAndHeaderFiles(results, outputPath):
 
     sourceFilenames = [filePrefix + ".cpp" for filePrefix in filesToWrite]
 
-    return sourceFilenames
+    return sourceFilenames, kernelsWithBuildErrs
 
 
 def markDuplicateKernels(

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -764,7 +764,7 @@ def writeKernels(
         (err, src) = ko.getSourceFileString()
         kernelSourceFile.write(src)
         if err:
-            printWarning("*** warning: invalid kernel#%u" % kernelName)
+            printWarning("Invalid kernel#%u" % kernelName)
 
         if not globalParameters["MergeFiles"]:
             kernelSourceFile.close()

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -42,7 +42,7 @@ import time
 import warnings
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Set, Tuple
+from typing import Any, Callable, Dict, List, Set, Tuple, Union
 
 from . import ClientExecutable, Common, EmbeddedData, LibraryIO, Utils
 from .Common import (
@@ -80,7 +80,7 @@ def processKernelSource(kernel, kernelWriterSource, kernelWriterAssembly):
     Returns (error, source, header, kernelName).
     """
     try:
-        kernelWriter: KernelWriterAssembly | KernelWriterSource = (
+        kernelWriter = (
             kernelWriterSource if kernel["KernelLanguage"] == "Source" else kernelWriterAssembly
         )
         # get kernel name
@@ -641,7 +641,7 @@ def filterProcessingErrors(
 def filterBuildErrors(
     kernels: List[Solution],
     kernelsWithBuildErrors: Dict[str, int],
-    writerSelectionFn: Callable[[str], KernelWriterSource | KernelWriterAssembly],
+    writerSelectionFn: Callable[[str], Union[KernelWriterSource, KernelWriterAssembly]],
     ignoreErr: bool,
 ) -> List[Solution]:
     """Filters a list of kernels based on build errors and error tolerance.

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -30,36 +30,6 @@ if __name__ == "__main__":
     )
     exit(1)
 
-from . import Common
-from . import ClientExecutable
-from . import EmbeddedData
-from . import LibraryIO
-from . import Utils
-from .Common import (
-    getArchitectureName,
-    globalParameters,
-    HR,
-    tPrint,
-    printExit,
-    ensurePath,
-    CHeader,
-    CMakeHeader,
-    assignGlobalParameters,
-    gfxName,
-    printWarning,
-    supportedCompiler,
-    which,
-)
-from .KernelWriterAssembly import KernelWriterAssembly
-from .KernelWriterSource import KernelWriterSource
-from .KernelWriterBase import KernelWriterBase
-from .SolutionLibrary import MasterSolutionLibrary
-from .SolutionStructs import Solution
-from .Utilities.String import splitDelimitedString
-from .Utilities.Profile import profile
-from .Utilities.toFile import toFile
-from .TensileCreateLib.ParseArguments import parseArguments
-
 import collections
 import itertools
 import os
@@ -70,10 +40,24 @@ import subprocess
 import sys
 import time
 import warnings
-
 from copy import deepcopy
-from typing import  Dict, Any, Set, List, Tuple, Callable
 from pathlib import Path
+from typing import Any, Callable, Dict, List, Set, Tuple
+
+from . import ClientExecutable, Common, EmbeddedData, LibraryIO, Utils
+from .Common import (HR, CHeader, CMakeHeader, assignGlobalParameters,
+                     ensurePath, getArchitectureName, gfxName,
+                     globalParameters, printExit, printWarning,
+                     supportedCompiler, tPrint, which)
+from .KernelWriterAssembly import KernelWriterAssembly
+from .KernelWriterBase import KernelWriterBase
+from .KernelWriterSource import KernelWriterSource
+from .SolutionLibrary import MasterSolutionLibrary
+from .SolutionStructs import Solution
+from .TensileCreateLib.ParseArguments import parseArguments
+from .Utilities.Profile import profile
+from .Utilities.String import splitDelimitedString
+from .Utilities.toFile import toFile
 
 TENSILE_MANIFEST_FILENAME = "TensileManifest.txt"
 TENSILE_LIBRARY_DIR = "library"

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -561,6 +561,42 @@ def buildKernelSourceAndHeaderFiles(results, outputPath, kernelsWithBuildErrs):
     return sourceFilenames
 
 
+def markDuplicateKernels(
+    kernels: List[Solution], kernelWriterAssembly: KernelWriterAssembly
+) -> List[Solution]:
+    """Marks duplicate assembly kernels based on their generated base file names.
+
+    Kernels written in Assembly language may generate duplicate output file names,
+    leading to potential race conditions. This function identifies such duplicates within
+    the provided list of Solution objects and marks them to prevent issues.
+
+    Args:
+        kernels: A list of Solution objects representing kernels to be processed.
+
+    Returns:
+        A modified list of Solution objects where kernels identified as duplicates
+        are marked with a `duplicate` attribute indicating their duplication status.
+
+    Notes:
+        - This function sets the "duplicate" attribute on Solution objects, and thereby prepares
+        kernels for **processKernelSource**, which requires "duplicate" to be set.
+    """
+    # Kernels may be intended for different .co files, but generate the same .o file
+    # Mark duplicate kernels to avoid race condition
+    # @TODO improve organization so this problem doesn't appear
+    visited = set()
+    count = 0
+    for kernel in kernels:
+        if kernel["KernelLanguage"] == "Assembly":
+            curr = kernelWriterAssembly.getKernelFileBase(kernel)
+            kernel.duplicate = curr in visited
+            count += kernel.duplicate
+            visited.add(curr)
+    if count:
+        printWarning(f"Found {count} duplicate kernels, these will be ignored")
+    return kernels
+
+
 ################################################################################
 # Write Solutions and Kernels for BenchmarkClient or LibraryClient
 ################################################################################
@@ -612,18 +648,7 @@ def writeKernels(
         params["PrintLevel"],
     )
 
-    # Kernels may be intended for different co files, but generate the same .o file
-    # Mark duplicate kernels to avoid race condition
-    # @TODO improve organization so this problem doesn't appear
-    objFilenames = set()
-    for kernel in kernels:
-        if kernel["KernelLanguage"] == "Assembly":
-            base = kernelWriterAssembly.getKernelFileBase(kernel)
-            if base in objFilenames:
-                kernel.duplicate = True
-            else:
-                objFilenames.add(base)
-                kernel.duplicate = False
+    kernels = markDuplicateKernels(kernels, kernelWriterAssembly)
 
     kIter = zip(
         kernels,
@@ -754,7 +779,7 @@ def writeKernels(
 ##############################################################################
 # Min Naming / Solution and Kernel Writers
 ##############################################################################
-def getKernelWriters(solutions, kernels):
+def getKernelWriters(solutions: List[Solution], kernels: List[Solution]):
 
     # if any kernels are assembly, append every ISA supported
     kernelSerialNaming = Solution.getSerialNaming(kernels)
@@ -1073,7 +1098,9 @@ def writeCMake(outputPath, solutionFiles, kernelFiles, libraryStaticFiles, maste
 ################################################################################
 # Generate Kernel Objects From Solutions
 ################################################################################
-def generateKernelObjectsFromSolutions(solutions):
+def generateKernelObjectsFromSolutions(
+    solutions: List[Solution],
+) -> Tuple[List[Solution], List[KernelWriterBase], List[str]]:
     # create solution writer and kernel writer
     kernels = []
     kernelHelperObjs = []

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -475,7 +475,7 @@ def buildKernelSourceAndHeaderFiles(results, outputPath):
 
     # Find kernels to write
     kernelsToWrite = []
-    kernelsWithBuildErrs = {}
+    kernelsWithBuildErrs: Dict[str, int] = {}
     filesToWrite = collections.defaultdict(list)
     validKernelCount = 0
     for err, src, header, kernelName, filename in results:
@@ -629,9 +629,9 @@ def filterProcessingErrors(
 
 def filterBuildErrors(
     kernels: List[Solution],
-    kernelsWithBuildErrors: List[Solution],
+    kernelsWithBuildErrors: Dict[str, int],
     writerSelectionFn: Callable[[str], KernelWriterSource | KernelWriterAssembly],
-    errorTolerant: bool,
+    ignoreErr: bool,
 ):
     """
     Filters a list of kernels based on build errors and error tolerance.
@@ -647,7 +647,7 @@ def filterBuildErrors(
     Raises:
         SystemExit: If **error_tolerant** is False and any kernels have build errors.
     """
-    if not errorTolerant and len(kernelsWithBuildErrors) > 0:
+    if not ignoreErr and len(kernelsWithBuildErrors) > 0:
         printExit(
             "** Kernel compilation failure **"
             "Kernel compilation failed in one or more subprocesses. "

--- a/Tensile/Tests/unit/test_TensileCreateLibrary.py
+++ b/Tensile/Tests/unit/test_TensileCreateLibrary.py
@@ -22,6 +22,7 @@
 #
 ################################################################################
 
+from copy import deepcopy
 import logging
 import pytest
 import os
@@ -42,6 +43,7 @@ from typing import List
 
 mylogger = logging.getLogger()
 
+
 def test_loadSolutions(caplog, useGlobalParameters):
     with useGlobalParameters():
         mylogger.debug("this is a test of debug log")
@@ -56,9 +58,7 @@ def test_loadSolutions(caplog, useGlobalParameters):
         assert len(solutions) == 3
         assert len(kernels) == 3
 
-
-        _, kernelWriterAssembly, \
-            _, _ = TensileCreateLibrary.getKernelWriters(solutions, kernels)
+        _, kernelWriterAssembly, _, _ = TensileCreateLibrary.getKernelWriters(solutions, kernels)
 
         expectedKernelName0 = "Cijk_Ailk_Bljk_SB_MT128x128x2_SE_K1_TT8_8_WG16_16_1"
         expectedKernelName1 = "Cijk_Ailk_Bljk_SB_MT64x64x2_SE_K1_TT4_4_WG16_16_1"
@@ -72,6 +72,7 @@ def test_loadSolutions(caplog, useGlobalParameters):
         assert expectedKernelName1 == actualKernelName1
         assert expectedKernelName2 == actualKernelName2
 
+
 @pytest.mark.skip(reason="System issue with find assempler called when assigning defaults")
 def test_WriteClientLibraryFromSolutions(tmpdir):
     Common.globalParameters["MergeFiles"] = True
@@ -82,7 +83,6 @@ def test_WriteClientLibraryFromSolutions(tmpdir):
 
     libraryWorkingPath = tmpdir.mkdir("lib")
     buildWorkingPath = tmpdir.mkdir("build")
-
 
     scriptDir = os.path.dirname(os.path.realpath(__file__))
     dataDir = os.path.realpath(os.path.join(scriptDir, "..", "test_data", "unit"))
@@ -98,10 +98,10 @@ def test_WriteClientLibraryFromSolutions(tmpdir):
     tensileLibraryPath = os.path.join(libraryWorkingPath, "library")
 
     hsacoFiles = glob.glob(tensileLibraryPath + "/*hsaco")
-    assert (len(hsacoFiles) > 0)
+    assert len(hsacoFiles) > 0
 
     coFiles = glob.glob(tensileLibraryPath + "/*TensileLibrary*co")
-    assert (len(coFiles) > 0)
+    assert len(coFiles) > 0
 
     tensileYamlFilePath = os.path.join(tensileLibraryPath, "TensileLibrary.yaml")
     assert os.path.exists(tensileYamlFilePath) == 1
@@ -115,7 +115,7 @@ def test_WriteClientLibraryFromSolutions(tmpdir):
     stream.close()
     actualSolutions = config["solutions"]
 
-    assert (len(actualSolutions) == 3)
+    assert len(actualSolutions) == 3
 
     metadataYamlFilePath = os.path.join(tensileLibraryPath, "metadata.yaml")
     assert os.path.exists(metadataYamlFilePath) == 1
@@ -129,11 +129,12 @@ def test_WriteClientLibraryFromSolutions(tmpdir):
     stream.close()
     actualProblemType = metadata["ProblemType"]
 
-    assert (len(actualProblemType) > 0)
+    assert len(actualProblemType) > 0
+
 
 def test_CreateBenchmarkClientParametersForSizes(tmpdir):
 
-    Common.globalParameters["CurrentISA"] = (9,0,6)
+    Common.globalParameters["CurrentISA"] = (9, 0, 6)
     dataWorkingPath = tmpdir.mkdir("Data")
     configWorkingPath = tmpdir.mkdir("run_configs")
     scriptDir = os.path.dirname(os.path.realpath(__file__))
@@ -142,7 +143,6 @@ def test_CreateBenchmarkClientParametersForSizes(tmpdir):
     libraryPath = os.path.join(testDataPath, "library")
     metadataFilepath = os.path.join(libraryPath, "metadata.yaml")
 
-
     metadataFile = LibraryIO.readYAML(metadataFilepath)
     problemTypeDict = metadataFile["ProblemType"]
     sizes = [{"Exact": [196, 256, 64, 1024]}]
@@ -150,12 +150,15 @@ def test_CreateBenchmarkClientParametersForSizes(tmpdir):
 
     dataFilePath = os.path.join(dataWorkingPath, "results.csv")
     configFile = os.path.join(configWorkingPath, "ClientParameters.ini")
-    ClientWriter.CreateBenchmarkClientParametersForSizes(testDataPath, problemSizes, dataFilePath, configFile)
+    ClientWriter.CreateBenchmarkClientParametersForSizes(
+        testDataPath, problemSizes, dataFilePath, configFile
+    )
 
     assert os.path.exists(configFile) == 1
 
+
 def test_verifyManifest():
-  
+
     manifestFile = Path("test_manifest.txt")
     testFoo = Path("foo.asm")
     testBar = Path("bar.asm")
@@ -163,38 +166,53 @@ def test_verifyManifest():
     # ensure clean state before running test
     with contextlib.suppress(FileNotFoundError):
         os.remove(manifestFile)
-        os.remove(testFoo)    
+        os.remove(testFoo)
         os.remove(testBar)
 
     # Verification should fail if the manifest can't be found
-    with pytest.raises(FileNotFoundError, match=r"(.*) No such file or directory: 'test_manifest.txt'"):
+    with pytest.raises(
+        FileNotFoundError, match=r"(.*) No such file or directory: 'test_manifest.txt'"
+    ):
         TensileCreateLibrary.verifyManifest(manifestFile)
 
-    # Create an empty manifest 
+    # Create an empty manifest
     with open(manifestFile, mode="x") as manifest:
-           
-        assert TensileCreateLibrary.verifyManifest(manifestFile), "an empty manifest should always succeed"
+
+        assert TensileCreateLibrary.verifyManifest(
+            manifestFile
+        ), "an empty manifest should always succeed"
 
         # add to file manifest that is not on disk
         manifest.write("foo.asm\n")
         manifest.flush()
-        assert not TensileCreateLibrary.verifyManifest(manifestFile), "file in manifest are on disk, but shouldn't be"
-    
+        assert not TensileCreateLibrary.verifyManifest(
+            manifestFile
+        ), "file in manifest are on disk, but shouldn't be"
+
         with open(testFoo, mode="x"):
-            assert TensileCreateLibrary.verifyManifest(manifestFile), "file in manifest isn't on disk, but should be"
-    
+            assert TensileCreateLibrary.verifyManifest(
+                manifestFile
+            ), "file in manifest isn't on disk, but should be"
+
         manifest.write("bar.asm\n")
         manifest.flush()
-        assert not TensileCreateLibrary.verifyManifest(manifestFile), "bar.asm in manifest should not be on disk"
-  
+        assert not TensileCreateLibrary.verifyManifest(
+            manifestFile
+        ), "bar.asm in manifest should not be on disk"
+
     with open(testBar, mode="x"):
-      assert TensileCreateLibrary.verifyManifest(manifestFile), "files in manifest isn't on disk, but should be"
+        assert TensileCreateLibrary.verifyManifest(
+            manifestFile
+        ), "files in manifest isn't on disk, but should be"
 
-    with open(manifestFile, "a") as generatedFile:  
+    with open(manifestFile, "a") as generatedFile:
         for filePath in range(5):
-            generatedFile.write("%s\n" %(filePath) )
+            generatedFile.write("%s\n" % (filePath))
 
-    assert not TensileCreateLibrary.verifyManifest(manifestFile), "files in manifest are on disk, but shouldn't be"
+    assert not TensileCreateLibrary.verifyManifest(
+        manifestFile
+    ), "files in manifest are on disk, but shouldn't be"
+
 
 def test_findLogicFiles():
 
@@ -219,7 +237,9 @@ def test_findLogicFiles():
         for d in logicArchs:
             createDirectoryWithYamls(baseDir / d, "foo", "yaml")
 
-        result = TensileCreateLibrary.findLogicFiles(baseDir, logicArchs, lazyLoading, experimentalDir)
+        result = TensileCreateLibrary.findLogicFiles(
+            baseDir, logicArchs, lazyLoading, experimentalDir
+        )
         expected = findLogicFiles_oldLogic(baseDir, logicArchs, lazyLoading, experimentalDir)
         return result == expected
 
@@ -232,10 +252,12 @@ def test_findLogicFiles():
         for d in logicArchs:
             createDirectoryWithYamls(baseDir / d, d, "yaml")
 
-        result = TensileCreateLibrary.findLogicFiles(baseDir, logicArchs, lazyLoading, experimentalDir)
+        result = TensileCreateLibrary.findLogicFiles(
+            baseDir, logicArchs, lazyLoading, experimentalDir
+        )
         expected = findLogicFiles_oldLogic(baseDir, logicArchs, lazyLoading, experimentalDir)
         return result == expected
-    
+
     def outputMatchesOldLogic3():
         baseDir, lazyLoading, experimentalDir = setup()
         logicArchs = set(Common.architectureMap["all"])
@@ -243,7 +265,9 @@ def test_findLogicFiles():
         for d in logicArchs:
             createDirectoryWithYamls(baseDir / d, d, "yaml")
 
-        result = TensileCreateLibrary.findLogicFiles(baseDir, logicArchs, lazyLoading, experimentalDir)
+        result = TensileCreateLibrary.findLogicFiles(
+            baseDir, logicArchs, lazyLoading, experimentalDir
+        )
         expected = findLogicFiles_oldLogic(baseDir, logicArchs, lazyLoading, experimentalDir)
         return result == expected
 
@@ -258,14 +282,18 @@ def test_findLogicFiles():
             createDirectoryWithYamls(baseDir / "yaml" / d, d, "yaml")
             createDirectoryWithYamls(baseDir / "yml" / d, d, "yml")
 
-        result = TensileCreateLibrary.findLogicFiles(baseDir, logicArchs, lazyLoading, experimentalDir)
+        result = TensileCreateLibrary.findLogicFiles(
+            baseDir, logicArchs, lazyLoading, experimentalDir
+        )
         expected = findLogicFiles_oldLogic(baseDir, logicArchs, lazyLoading, experimentalDir)
-        return len(result) == len(expected)*2
+        return len(result) == len(expected) * 2
 
     assert outputMatchesOldLogic1(), "Output differs from old logic, not backwards compatible."
     assert outputMatchesOldLogic2(), "Output differs from old logic, not backwards compatible."
     assert outputMatchesOldLogic3(), "Output differs from old logic, not backwards compatible."
-    assert verifyYamlAndYml(), "Output should have twice as many files as old logic (which only parses .yaml)"
+    assert (
+        verifyYamlAndYml()
+    ), "Output should have twice as many files as old logic (which only parses .yaml)"
 
 
 def test_sanityCheck():
@@ -298,61 +326,69 @@ def test_sanityCheck():
         except:
             raise Exception
 
+
 def test_generateClientConfig():
-    
+
     outputPath: Path = Path.cwd() / "my-output"
-    masterLibrary: Path = outputPath / "masterlib.data" 
+    masterLibrary: Path = outputPath / "masterlib.data"
     codeObjectFiles = ["library/foo.hsaco", "library/bar.co"]
     configFile = outputPath / "best-solution.ini"
-    
+
     cleanClientConfigTest(outputPath, masterLibrary, codeObjectFiles, configFile)
 
-    with pytest.raises(FileNotFoundError, match=r"(.*) No such file or directory: '(.*)/my-output/best-solution.ini'"): 
-        TensileCreateLibrary.generateClientConfig(outputPath, masterLibrary, codeObjectFiles)        
+    with pytest.raises(
+        FileNotFoundError,
+        match=r"(.*) No such file or directory: '(.*)/my-output/best-solution.ini'",
+    ):
+        TensileCreateLibrary.generateClientConfig(outputPath, masterLibrary, codeObjectFiles)
 
     setupClientConfigTest(outputPath, masterLibrary, codeObjectFiles)
 
     TensileCreateLibrary.generateClientConfig(outputPath, masterLibrary, codeObjectFiles)
 
     assert configFile.is_file(), "{configFile} was not generated"
-    
+
     with open(configFile, "r") as f:
         result = f.readlines()
         assert "library-file" in result[0], "missing library-file entry"
         assert "code-object" in result[1], "missing code-object entry"
-        assert "code-object" in result[2], "missing code-object entry"        
-        assert "best-solution" in result[3], "missing best-solution entry"                
+        assert "code-object" in result[2], "missing code-object entry"
+        assert "best-solution" in result[3], "missing best-solution entry"
 
     cleanClientConfigTest(outputPath, masterLibrary, codeObjectFiles, configFile)
+
 
 class MasterLibraryMock:
     def __init__(self, libraries, data):
         self.lazyLibraries = libraries
         self.data = data
 
+
 def test_generateMasterFileList():
-  
-  archs = ["arch0", "arch1"]  
-  libraries = {"arch0" : MasterLibraryMock({"mylib0" : MasterLibraryMock(None, 2)}, 0),
-               "arch1" : MasterLibraryMock({"mylib1" : MasterLibraryMock(None, 3)}, 1)}
 
-  result = TensileCreateLibrary.generateMasterFileList(libraries, archs, lazy=False)
-  for idx, t in enumerate(result):
-    assert t[0] == "TensileLibrary_arch" + str(idx), "Incorrect naming for key."
-    assert isinstance(t[1], MasterLibraryMock), "Incorrect type for value."
-    assert t[1].data == idx, "Incorrect data."    
-  
-  result = TensileCreateLibrary.generateMasterFileList(libraries, archs, lazy=True)
+    archs = ["arch0", "arch1"]
+    libraries = {
+        "arch0": MasterLibraryMock({"mylib0": MasterLibraryMock(None, 2)}, 0),
+        "arch1": MasterLibraryMock({"mylib1": MasterLibraryMock(None, 3)}, 1),
+    }
 
-  for idx, t in enumerate(result[0:2]):
-    assert t[0] == "TensileLibrary_lazy_arch" + str(idx), "Incorrect naming for key."
-    assert isinstance(t[1], MasterLibraryMock), "Incorrect type for value."
-    assert t[1].data == idx, "Incorrect data."    
+    result = TensileCreateLibrary.generateMasterFileList(libraries, archs, lazy=False)
+    for idx, t in enumerate(result):
+        assert t[0] == "TensileLibrary_arch" + str(idx), "Incorrect naming for key."
+        assert isinstance(t[1], MasterLibraryMock), "Incorrect type for value."
+        assert t[1].data == idx, "Incorrect data."
 
-  for idx, t in enumerate(result[2:4]):
-    assert t[0] == "mylib" + str(idx), "Incorrect naming for key."
-    assert isinstance(t[1], MasterLibraryMock), "Incorrect type for value."
-    assert t[1].data == (idx+2), "Incorrect data."        
+    result = TensileCreateLibrary.generateMasterFileList(libraries, archs, lazy=True)
+
+    for idx, t in enumerate(result[0:2]):
+        assert t[0] == "TensileLibrary_lazy_arch" + str(idx), "Incorrect naming for key."
+        assert isinstance(t[1], MasterLibraryMock), "Incorrect type for value."
+        assert t[1].data == idx, "Incorrect data."
+
+    for idx, t in enumerate(result[2:4]):
+        assert t[0] == "mylib" + str(idx), "Incorrect naming for key."
+        assert isinstance(t[1], MasterLibraryMock), "Incorrect type for value."
+        assert t[1].data == (idx + 2), "Incorrect data."
 
 
 def test_logicDataAndSolutionsConstruction(initGlobalParametersForTCL):
@@ -361,20 +397,28 @@ def test_logicDataAndSolutionsConstruction(initGlobalParametersForTCL):
         # clear the set to prevent testing errors caused
         # by the fact that ArchitectureSet is shared across
         # instances of MasterSolutionLibrary.
-        SolutionLibrary.MasterSolutionLibrary.ArchitectureSet.clear()    
+        SolutionLibrary.MasterSolutionLibrary.ArchitectureSet.clear()
 
-        masterLibraries = TensileCreateLibrary.makeMasterLibraries(logicFiles, separate=separateArch)
+        masterLibraries = TensileCreateLibrary.makeMasterLibraries(
+            logicFiles, separate=separateArch
+        )
         arch = "gfx900" if separateArch else "full"
-        
-        if separateArch:        
-            assert len(masterLibraries[arch].solutions.values()) == 17, f"There should be 17 solutions prior to adding the fallback for {arch}."
-        
+
+        if separateArch:
+            assert (
+                len(masterLibraries[arch].solutions.values()) == 17
+            ), f"There should be 17 solutions prior to adding the fallback for {arch}."
+
             TensileCreateLibrary.addFallback(masterLibraries)
-        
-            assert len(masterLibraries[arch].solutions.values()) == 19, f"There should be 19 solutions after adding the fallback for {arch}."
+
+            assert (
+                len(masterLibraries[arch].solutions.values()) == 19
+            ), f"There should be 19 solutions after adding the fallback for {arch}."
         else:
-            assert len(masterLibraries[arch].solutions.values()) == 19, f"There should be 19 solutions for {arch}."
-        
+            assert (
+                len(masterLibraries[arch].solutions.values()) == 19
+            ), f"There should be 19 solutions for {arch}."
+
         solutions = TensileCreateLibrary.generateSolutions(masterLibraries, separate=separateArch)
         assert isinstance(solutions, list), "generateSolutions should return a list."
         assert len(solutions) == 19, "There should be 19 solutions after adding the fallback."
@@ -383,13 +427,17 @@ def test_logicDataAndSolutionsConstruction(initGlobalParametersForTCL):
         # clear the set to prevent testing errors caused
         # by the fact that ArchitectureSet is shared across
         # instances of MasterSolutionLibrary.
-        SolutionLibrary.MasterSolutionLibrary.ArchitectureSet.clear()    
+        SolutionLibrary.MasterSolutionLibrary.ArchitectureSet.clear()
 
-        masterLibraries = TensileCreateLibrary.generateLogicData(yamlFiles,version="foo", printLevel=0, separate=separateArch)
+        masterLibraries = TensileCreateLibrary.generateLogicData(
+            yamlFiles, version="foo", printLevel=0, separate=separateArch
+        )
         arch = "gfx900" if separateArch else "full"
-        
-        assert len(masterLibraries[arch].solutions.values()) == 19, f"There should be 19 solutions for {arch}."
-        
+
+        assert (
+            len(masterLibraries[arch].solutions.values()) == 19
+        ), f"There should be 19 solutions for {arch}."
+
         solutions = TensileCreateLibrary.generateSolutions(masterLibraries, separate=separateArch)
         assert isinstance(solutions, list), "generateSolutions should return a list."
         assert len(solutions) == 19, "There should be 19 solutions after adding the fallback."
@@ -398,56 +446,69 @@ def test_logicDataAndSolutionsConstruction(initGlobalParametersForTCL):
         # clear the set to prevent testing errors caused
         # by the fact that ArchitectureSet is shared across
         # instances of MasterSolutionLibrary.
-        SolutionLibrary.MasterSolutionLibrary.ArchitectureSet.clear()    
+        SolutionLibrary.MasterSolutionLibrary.ArchitectureSet.clear()
 
         masterLibraries = TensileCreateLibrary.makeMasterLibraries(logicFiles, separate=True)
         arch = "gfx900"
-        
-        assert len(masterLibraries[arch].lazyLibraries.keys()) == 1, f"There should be 1 key prior to adding the fallback for {arch}."        
-        assert len(next(iter(masterLibraries[arch].lazyLibraries.values())).solutions.values()) == 17, f"There should be 17 solutions prior to adding the fallback for {arch}."
-       
+
+        assert (
+            len(masterLibraries[arch].lazyLibraries.keys()) == 1
+        ), f"There should be 1 key prior to adding the fallback for {arch}."
+        assert (
+            len(next(iter(masterLibraries[arch].lazyLibraries.values())).solutions.values()) == 17
+        ), f"There should be 17 solutions prior to adding the fallback for {arch}."
+
         TensileCreateLibrary.addFallback(masterLibraries)
-       
-        assert len(masterLibraries[arch].lazyLibraries.keys()) == 2, f"There should be 2 keys after adding the fallback for {arch}."
+
+        assert (
+            len(masterLibraries[arch].lazyLibraries.keys()) == 2
+        ), f"There should be 2 keys after adding the fallback for {arch}."
 
         for name, lib in masterLibraries[arch].lazyLibraries.items():
             if "fallback" in name:
                 assert len(lib.solutions.values()) == 2, "There should be 2 fallback solutions."
             else:
                 assert len(lib.solutions.values()) == 17, "There should be 17 gfx900 solutions."
- 
+
         solutions = TensileCreateLibrary.generateSolutions(masterLibraries, separate=True)
         assert isinstance(solutions, list), "generateSolutions should return a list."
         assert len(solutions) == 19, "There should be 19 solutions after adding the fallback."
 
-
     requiredArgs = ["--jobs=2", "/unused/logic/path", "/unused/output/path", "HIP"]
-    rootPath = Path(__file__).parent.parent/"test_data"/"unit"/"solutions"
-    yamlFiles = [rootPath/f for f in ["vega10_Cijk_Ailk_Bjlk_CB_GB.yaml", "hip_Cijk_Ailk_Bjlk_CB_GB.yaml"]]
-    
-    with initGlobalParametersForTCL(["--architecture=gfx900"]+requiredArgs):
+    rootPath = Path(__file__).parent.parent / "test_data" / "unit" / "solutions"
+    yamlFiles = [
+        rootPath / f for f in ["vega10_Cijk_Ailk_Bjlk_CB_GB.yaml", "hip_Cijk_Ailk_Bjlk_CB_GB.yaml"]
+    ]
+
+    with initGlobalParametersForTCL(["--architecture=gfx900"] + requiredArgs):
         logicFiles = TensileCreateLibrary.parseLibraryLogicFiles(yamlFiles)
-        assert len(logicFiles) == 2, "The length of the logic files list is incorrect."        
-     
+        assert len(logicFiles) == 2, "The length of the logic files list is incorrect."
+
         for s in [True, False]:
             testCase1(logicFiles, separateArch=s)
             testCase2(yamlFiles, separateArch=s)
 
-    with initGlobalParametersForTCL(["--architecture=gfx900", "--lazy-library-loading"]+requiredArgs):
+    with initGlobalParametersForTCL(
+        ["--architecture=gfx900", "--lazy-library-loading"] + requiredArgs
+    ):
         logicFiles = TensileCreateLibrary.parseLibraryLogicFiles(yamlFiles)
         assert len(logicFiles) == 2, "The length of the logic files list is incorrect."
         testCase3(logicFiles)
 
+
 @pytest.fixture
-def testPath(request):
+def unittestPath(request):
     """Returns the path to the directory containing the current test file"""
     return request.path.parent
 
+
 @pytest.fixture
-def setupSolutionsAndKernels(testPath):
+def setupSolutionsAndKernels(unittestPath):
     """Reusable logic for setting up testable solutions and kernels"""
     Common.assignGlobalParameters({})
-    _, _, _, _, _, lib = LibraryIO.parseLibraryLogicFile(testPath.parent / "test_data" / "unit" / "aldebaran_Cijk_AlikC_Bljk_ZB_GB.yaml")
+    _, _, _, _, _, lib = LibraryIO.parseLibraryLogicFile(
+        unittestPath.parent / "test_data" / "unit" / "aldebaran_Cijk_AlikC_Bljk_ZB_GB.yaml"
+    )
     solutions = [sol.originalSolution for sol in lib.solutions.values()]
     kernels, _, _ = TensileCreateLibrary.generateKernelObjectsFromSolutions(solutions)
     kernelWriterSource, kernelWriterAssembly, _, _ = TensileCreateLibrary.getKernelWriters(
@@ -455,13 +516,16 @@ def setupSolutionsAndKernels(testPath):
     )
     return solutions, kernels, kernelWriterAssembly, kernelWriterSource
 
+
 def test_prepAsm(setupSolutionsAndKernels):
     solutions, kernels, kernelWriterAssembly, kernelWriterSource = setupSolutionsAndKernels
     buildPath = Path("no-commit-prep-asm")
     buildPath.mkdir(exist_ok=True)
 
     def testLinux():
-        TensileCreateLibrary.prepAsm(kernelWriterAssembly, True, Path("no-commit-prep-asm"), (9, 0, 10), 1)
+        TensileCreateLibrary.prepAsm(
+            kernelWriterAssembly, True, Path("no-commit-prep-asm"), (9, 0, 10), 1
+        )
 
         expected = """#!/bin/sh 
 # usage: asm-new.sh kernelName(no extension) [--wave32]
@@ -484,12 +548,14 @@ cp $f.co ../../../library/${f}_$h.co
 mkdir -p ../../../asm_backup && cp $f.s ../../../asm_backup/$f.s
 """
 
-        with open(buildPath/"assembly"/"asm-new.sh", "r") as f:
+        with open(buildPath / "assembly" / "asm-new.sh", "r") as f:
             contents = f.read()
             assert contents == expected, "Assembler script doesn't match expectation"
 
     def testWindows():
-        TensileCreateLibrary.prepAsm(kernelWriterAssembly, False, Path("no-commit-prep-asm"), (9, 0, 10), 1)
+        TensileCreateLibrary.prepAsm(
+            kernelWriterAssembly, False, Path("no-commit-prep-asm"), (9, 0, 10), 1
+        )
 
         expected = """@echo off
 set f=%1
@@ -506,21 +572,48 @@ if %wave% == 32 (/opt/rocm/bin/amdclang++ -x assembler -target amdgcn-amd-amdhsa
 copy %f%.co ..\..\..\library\%f%_%h%.co
 """
 
-        with open(buildPath/"assembly"/"asm-new.bat", "r") as f:
+        with open(buildPath / "assembly" / "asm-new.bat", "r") as f:
             contents = f.read()
             assert contents == expected, "Assembler script doesn't match expectation"
-    
+
     testLinux()
     testWindows()
+
+
+def test_markDuplicateKernels(setupSolutionsAndKernels):
+    _, kernels, kernelWriterAssembly, _ = setupSolutionsAndKernels
+
+    shortname_idx = 0
+    custom_idx1 = 1
+    custom_idx2 = 2
+
+    # Use deepcopy here, otherwise when the entry is updated later, both entries will be
+    # marked as duplicates.
+    kernels.append(deepcopy(kernels[shortname_idx]))
+    kernels[custom_idx1]["CustomKernelName"] = "DUPLICATE"
+    kernels[custom_idx2]["CustomKernelName"] = "DUPLICATE"
+
+    kernelsOut = TensileCreateLibrary.markDuplicateKernels(kernels, kernelWriterAssembly)
+
+    assert len(kernelsOut) == len(kernels), "Lengths of input and output should match"
+    for i, k in enumerate(kernelsOut):
+        if i == custom_idx2:
+            assert (
+                k.duplicate == True
+            ), f"Kernel with custom name {kernels[i]['CustomKernelName']} should be a duplicate, but isn't, found {kernelWriterAssembly.getKernelFileBase(k)} instead"
+        elif i == len(kernels) - 1:
+            assert (
+                k.duplicate == True
+            ), f"Shortened name {kernelWriterAssembly.getKernelFileBase(k)} wasn't located"
+        elif k["KernelLanguage"] == "Assembly":
+            assert (
+                k.duplicate == False
+            ), f"Kernel with name {kernels[i]['CustomKernelName']} should not be marked as a duplicate, but is"
+
 
 # ----------------
 # Helper functions
 # ----------------
-def makeLibraryLogicList(logicFiles: List[str], repeat: int) -> List[LibraryIO.LibraryLogic]:
-
-    return logicFiles
-
-
 def setupClientConfigTest(outputPath, masterLibrary, codeObjectFiles):
     outputPath.mkdir()
     with open(masterLibrary, "w") as testFile:
@@ -534,7 +627,7 @@ def setupClientConfigTest(outputPath, masterLibrary, codeObjectFiles):
 def cleanClientConfigTest(outputPath: Path, masterLibrary, codeObjectFiles, configFile):
     with contextlib.suppress(FileNotFoundError):
         os.remove(configFile)
-        os.remove(masterLibrary)        
+        os.remove(masterLibrary)
         for f in codeObjectFiles:
             os.remove(outputPath / f)
         next(outputPath.iterdir()).rmdir()
@@ -548,11 +641,12 @@ def createDirectoryWithYamls(currentDir, prefix, ext, depth=3, nChildren=3):
 
         currentDir.mkdir(parents=True, exist_ok=True)
         file = f"{prefix}_{str(uuid.uuid4().hex)}.{ext}"
-        with open(currentDir/file, mode="w"):
+        with open(currentDir / file, mode="w"):
             pass
 
         for n in range(nChildren):
             recurse(currentDir / str(n), depth - 1, nChildren)
+
     recurse(currentDir, depth, nChildren)
 
 
@@ -560,19 +654,25 @@ def findLogicFiles_oldLogic(logicPath, logicArchs, lazyLoading, experimentalDir)
     # Recursive directory search
     logicFiles = []
     for root, dirs, files in os.walk(str(logicPath)):
-        logicFiles += [os.path.join(root, f) for f in files
-                        if os.path.splitext(f)[1]==".yaml" \
-                        and (any(logicArch in os.path.splitext(f)[0] for logicArch in logicArchs) \
-                        or "hip" in os.path.splitext(f)[0]) ]
+        logicFiles += [
+            os.path.join(root, f)
+            for f in files
+            if os.path.splitext(f)[1] == ".yaml"
+            and (
+                any(logicArch in os.path.splitext(f)[0] for logicArch in logicArchs)
+                or "hip" in os.path.splitext(f)[0]
+            )
+        ]
 
     if not lazyLoading:
         logicFiles = [f for f in logicFiles if not experimentalDir in f]
     return logicFiles
 
+
 def sanityCheck_oldLogic(sourceLibPaths, asmLibPaths, codeObjectFiles, genSourcesAndExit):
     bothLibSet = set(sourceLibPaths + asmLibPaths)
-    setA = set( map( os.path.normcase, set(codeObjectFiles) ) )
-    setB = set( map( os.path.normcase, bothLibSet ) )
+    setA = set(map(os.path.normcase, set(codeObjectFiles)))
+    setB = set(map(os.path.normcase, bothLibSet))
 
     sanityCheck0 = setA - setB
     sanityCheck1 = setB - setA

--- a/Tensile/Tests/unit/test_TensileCreateLibrary.py
+++ b/Tensile/Tests/unit/test_TensileCreateLibrary.py
@@ -722,7 +722,7 @@ def test_filterBuildErrors(setupSolutionsAndKernels):
 
 # ----------------
 # Helper functions
-# --------------
+# ----------------
 def setupClientConfigTest(outputPath, masterLibrary, codeObjectFiles):
     outputPath.mkdir()
     with open(masterLibrary, "w") as testFile:

--- a/Tensile/Tests/unit/test_TensileCreateLibrary.py
+++ b/Tensile/Tests/unit/test_TensileCreateLibrary.py
@@ -24,8 +24,9 @@
 
 from copy import deepcopy
 import functools
+import contextlib
+import glob
 import logging
-import pytest
 import os
 import glob
 import Tensile.TensileCreateLibrary as TensileCreateLibrary
@@ -38,11 +39,19 @@ import yaml
 import contextlib
 import uuid
 import shutil
-
+import uuid
 from pathlib import Path
 from typing import List
 
 import TensileCreateLibrary as tcl
+import pytest
+import yaml
+
+import Tensile.ClientWriter as ClientWriter
+import Tensile.Common as Common
+import Tensile.LibraryIO as LibraryIO
+import Tensile.SolutionStructs as SolutionStructs
+import Tensile.TensileCreateLibrary as TensileCreateLibrary
 
 mylogger = logging.getLogger()
 

--- a/Tensile/Tests/unit/test_TensileCreateLibrary.py
+++ b/Tensile/Tests/unit/test_TensileCreateLibrary.py
@@ -611,6 +611,26 @@ def test_markDuplicateKernels(setupSolutionsAndKernels):
             ), f"Kernel with name {kernels[i]['CustomKernelName']} should not be marked as a duplicate, but is"
 
 
+def test_filterProcessingErrors(setupSolutionsAndKernels):
+    solutions, kernels, kernelWriterAssembly, kernelWriterSource = setupSolutionsAndKernels
+    kernels = TensileCreateLibrary.markDuplicateKernels(kernels, kernelWriterAssembly)
+
+    results = [(-2, 0, 0, 0, 0)] * len(kernels)
+
+    kernelsOut, solutionsOut, resultsOut = TensileCreateLibrary.filterProcessingErrors(
+        kernels, solutions, results, printLevel=1, ignoreErr=True
+    )
+    assert len(kernelsOut) == 0, "Kernels should be of length zero"
+    assert len(solutionsOut) == 0, "Solutions should be of length zero"
+    assert len(resultsOut) == 0, "Results should be of length zero"
+
+    results = [(-2, 0, 0, 0, 0)] + [(0, 0, 0, 0, 0)] * (len(kernels) - 1)
+    with pytest.raises(ValueError, match=r"Found 1 error\(s\) (.*)"):
+        TensileCreateLibrary.filterProcessingErrors(
+            kernels, solutions, results, printLevel=1, ignoreErr=False
+        )
+
+
 # ----------------
 # Helper functions
 # ----------------

--- a/Tensile/Tests/unit/test_TensileCreateLibrary.py
+++ b/Tensile/Tests/unit/test_TensileCreateLibrary.py
@@ -574,6 +574,9 @@ class MockKernelWriter:
     def getKernelFileBase(self, kernel: MockSolution):
         return kernel.name
 
+    def getKernelName(self, kernel: MockSolution):
+        return f"{kernel.name}_name"
+
 
 def test_markDuplicateKernels():
 
@@ -712,8 +715,8 @@ def test_filterBuildErrors():
     kernels += [MockSolution(name, "Source") for name in ["D", "E", "F"]]
     kernelWriter = MockKernelWriter()
     kernelsWithBuildErrors = {
-        "A": -2,
-        "D": -2,
+        "A_name": -2,
+        "D_name": -2,
     }
     writerSelector = lambda lang: kernelWriter
 
@@ -722,13 +725,16 @@ def test_filterBuildErrors():
         assert kernelsToBuild == kernels, "All kernels should be built without failure"
 
     def buildFailuresIgnoreErr():
-        kernelsToBuild = tcl.filterBuildErrors(
-            kernels, kernelsWithBuildErrors, writerSelector, ignoreErr=True
-        )
 
         expectedKernelsToBuild = [MockSolution(name, "Assembly") for name in ["B", "C"]]
         expectedKernelsToBuild += [MockSolution(name, "Source") for name in ["E", "F"]]
 
+        kernelsToBuild = tcl.filterBuildErrors(
+            kernels, kernelsWithBuildErrors, writerSelector, ignoreErr=True
+        )
+
+        print("Kernels wtih build errors:", [k for k in kernelsWithBuildErrors])
+        print("Kernels to build:", [k.name for k in kernelsToBuild])
         assert len(kernelsToBuild) == len(
             expectedKernelsToBuild
         ), "Length of built kernels is incorrect"

--- a/docs/src/api-reference/TensileCreateLibrary.rst
+++ b/docs/src/api-reference/TensileCreateLibrary.rst
@@ -7,6 +7,7 @@ TensileCreateLibrary
 
 .. autofunction:: Tensile.TensileCreateLibrary::prepAsm
 .. autofunction:: Tensile.TensileCreateLibrary::markDuplicateKernels
+.. autofunction:: Tensile.TensileCreateLibrary::filterProcessingErrors
 .. autofunction:: Tensile.TensileCreateLibrary::addFallBacks
 .. autofunction:: Tensile.TensileCreateLibrary::addNewLibrary
 .. autofunction:: Tensile.TensileCreateLibrary::applyNaming    

--- a/docs/src/api-reference/TensileCreateLibrary.rst
+++ b/docs/src/api-reference/TensileCreateLibrary.rst
@@ -5,6 +5,8 @@
 TensileCreateLibrary
 ====================
 
+.. autofunction:: Tensile.TensileCreateLibrary::prepAsm
+.. autofunction:: Tensile.TensileCreateLibrary::markDuplicateKernels
 .. autofunction:: Tensile.TensileCreateLibrary::addFallBacks
 .. autofunction:: Tensile.TensileCreateLibrary::addNewLibrary
 .. autofunction:: Tensile.TensileCreateLibrary::applyNaming    

--- a/docs/src/api-reference/TensileCreateLibrary.rst
+++ b/docs/src/api-reference/TensileCreateLibrary.rst
@@ -8,6 +8,7 @@ TensileCreateLibrary
 .. autofunction:: Tensile.TensileCreateLibrary::prepAsm
 .. autofunction:: Tensile.TensileCreateLibrary::markDuplicateKernels
 .. autofunction:: Tensile.TensileCreateLibrary::filterProcessingErrors
+.. autofunction:: Tensile.TensileCreateLibrary::filterBuildErrors
 .. autofunction:: Tensile.TensileCreateLibrary::addFallBacks
 .. autofunction:: Tensile.TensileCreateLibrary::addNewLibrary
 .. autofunction:: Tensile.TensileCreateLibrary::applyNaming    

--- a/tox.ini
+++ b/tox.ini
@@ -65,6 +65,7 @@ skip_install = true
 deps = isort==5.13.2
 commands = 
     isort \
+      --profile=black \
       {toxinidir}/Tensile/TensileCreateLibrary.py \
       {toxinidir}/Tensile/TensileCreateLib/__init__.py \
       {toxinidir}/Tensile/TensileCreateLib/ParseArguments.py \

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 requires = tox>=4
 toxworkdir=/tmp/.tensile-tox
 labels =
-    precommit = format, lint, unittest
-    static = format, lint
+    precommit = format, lint, isort, unittest
+    static = format, lint, isort
 
 
 [vars]
@@ -53,6 +53,18 @@ deps = black==24.4
 commands = 
     black \
       --line-length=100 \
+      {toxinidir}/Tensile/TensileCreateLibrary.py \
+      {toxinidir}/Tensile/TensileCreateLib/__init__.py \
+      {toxinidir}/Tensile/TensileCreateLib/ParseArguments.py \
+      {toxinidir}/Tensile/Tests/unit/test_TensileCreateLibrary.py \
+      {posargs}
+
+[testenv:isort]
+description = "Sorts import statements for less merge conflicts"
+skip_install = true
+deps = isort==5.13.2
+commands = 
+    isort \
       {toxinidir}/Tensile/TensileCreateLibrary.py \
       {toxinidir}/Tensile/TensileCreateLib/__init__.py \
       {toxinidir}/Tensile/TensileCreateLib/ParseArguments.py \

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,7 @@ commands =
       {toxinidir}/Tensile/TensileCreateLibrary.py \
       {toxinidir}/Tensile/TensileCreateLib/__init__.py \
       {toxinidir}/Tensile/TensileCreateLib/ParseArguments.py \
+      {toxinidir}/Tensile/Tests/unit/test_TensileCreateLibrary.py \
       {posargs}
 
 [flake8]


### PR DESCRIPTION
Simple refactor:
1. Add a function in TensileCreateLibrary.py to filter kernels that emit and error when building (relates to kernel writing logic).
2. Add **isort** to automatically sort import for select files—reduces merge conflicts.
3. Update `printExit` to display red.

**Testing**

Unit tests are added for the new function and existing related functions.

**Notable changes**

1. The `TensileCreateLibrary` import in *test_TensileCreateLibrary* is renamed to `tcl`. So all functions should be accessed like `tcl.functionName(...)`.
2. An import sorting check has been added to CI, so make sure to run `tox run -m static` prior to committing to ensure formatting, linting, and import sorting are all complete.