### PR TITLE
Update duplicate marking tests with mocks

### DIFF
--- a/Tensile/Tests/unit/test_TensileCreateLibrary.py
+++ b/Tensile/Tests/unit/test_TensileCreateLibrary.py
@@ -22,9 +22,7 @@
 #
 ################################################################################
 
-from copy import deepcopy
 import logging
-from re import match
 import pytest
 import os
 import glob


### PR DESCRIPTION
Add `MockSolution` and `MockKernelWriter` for testing TensileCreateLibrary.