### PR TITLE
Use conditional imports for new dependencies

### DIFF
--- a/HostLibraryTests/configs/ConvertYAML.py
+++ b/HostLibraryTests/configs/ConvertYAML.py
@@ -24,6 +24,7 @@
 
 from __future__ import print_function
 
+
 import itertools
 import sys
 import time
@@ -32,7 +33,7 @@ import yaml
 sys.path.append('../..')
 from Tensile.SolutionStructs import Solution
 from Tensile import Utils
-
+from Tensile.Utilities.ConditionalImports import yamlDumper
 
 def merge_libraries(args):
     inFiles = args[:-1]
@@ -55,7 +56,7 @@ def merge_libraries(args):
 
     with open(outFile, 'w') as outf:
         if True:
-            yaml.dump(outData, outf, yaml.CSafeDumper)
+            yaml.dump(outData, outf, yamlDumper)
         else:
             import json
             json.dump(outData, outf, sort_keys=True, indent=2, separators=(",", ": "))
@@ -82,7 +83,7 @@ def convert_one(args):
 
     with open(args[1], 'w') as outFile:
         if True:
-            yaml.dump(outData, outFile, yaml.CSafeDumper)
+            yaml.dump(outData, outFile, yamlDumper)
         else:
             import json
             json.dump(outData, outFile, sort_keys=True, indent=2, separators=(",", ": "))

--- a/HostLibraryTests/configs/ConvertYAML.py
+++ b/HostLibraryTests/configs/ConvertYAML.py
@@ -24,7 +24,6 @@
 
 from __future__ import print_function
 
-
 import itertools
 import sys
 import time

--- a/Tensile/BenchmarkSplitter.py
+++ b/Tensile/BenchmarkSplitter.py
@@ -25,6 +25,7 @@
 import os
 import copy
 import yaml
+from Tensile.Utilities.ConditionalImports import yamlDumper, yamlLoader
 import math
 
 class BenchmarkSplitter(object):
@@ -39,7 +40,7 @@ class BenchmarkSplitter(object):
     @staticmethod
     def __readConfigFile(benchmarkConfigFile):
         with open(benchmarkConfigFile) as f:
-            data = yaml.load(f, yaml.CSafeLoader)
+            data = yaml.load(f, yamlLoader)
         return data
 
     # data: a loaded .yaml file
@@ -191,4 +192,4 @@ class BenchmarkSplitter(object):
         for i in range(len(benchmarksBySize)):
             outFileName = BenchmarkSplitter.__appendFileNameSuffix(outputFileBase, i, separator, suffixFormat)
             with open(outFileName, "w") as f:
-                yaml.dump(benchmarksBySize[i], f, yaml.CSafeDumper)
+                yaml.dump(benchmarksBySize[i], f, yamlDumper)

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -24,6 +24,7 @@
 
 from . import __version__
 from . import Parallel
+from .Utilities.ConditionalImports import *
 from collections import OrderedDict
 from copy import deepcopy
 from .AsmCaps import CACHED_ASM_CAPS
@@ -47,7 +48,10 @@ class DeveloperWarning(Warning):
     """
 
 def showwarning(message, category, filename, lineno, file=None, line=None):
-    print(f"{category.__name__}: {message}")
+    msg = f"{category.__name__}: {message}"
+    if TENSILE_TERM_COLORS:
+        msg = f"[yellow]{msg}[/yellow]"
+    print(msg)
 
 warnings.showwarning = showwarning
 

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -35,7 +35,6 @@ import subprocess
 import sys
 import time
 import warnings
-import rich
 
 startTime = time.time()
 
@@ -48,7 +47,7 @@ class DeveloperWarning(Warning):
     """
 
 def showwarning(message, category, filename, lineno, file=None, line=None):
-    rich.print(f"[yellow]{category.__name__}: {message}[/yellow]")
+    print(f"{category.__name__}: {message}")
 
 warnings.showwarning = showwarning
 
@@ -1986,7 +1985,7 @@ def tPrint(verbosity: int, arg) -> None:
         print(arg)
         sys.stdout.flush()
 
-def printWarning(message: str, category: type[Warning]=DeveloperWarning):
+def printWarning(message: str, category=DeveloperWarning):
   warnings.warn(message, category)
   sys.stdout.flush()
 

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -24,7 +24,7 @@
 
 from . import __version__
 from . import Parallel
-from .Utilities.ConditionalImports import showwarning
+from .Utilities.ConditionalImports import print, TENSILE_TERM_COLORS
 from collections import OrderedDict
 from copy import deepcopy
 from .AsmCaps import CACHED_ASM_CAPS
@@ -46,6 +46,12 @@ class DeveloperWarning(Warning):
 
     This warning can be safely ignored when running any Tensile applications as a user.
     """
+
+def showwarning(message, category, filename, lineno, file=None, line=None):
+    msg = f"{category.__name__}: {message}"
+    if TENSILE_TERM_COLORS:
+        msg = f"[yellow]{msg}[/yellow]"
+    print(msg)
 
 warnings.showwarning = showwarning
 

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -24,7 +24,7 @@
 
 from . import __version__
 from . import Parallel
-from .Utilities.ConditionalImports import *
+from .Utilities.ConditionalImports import showwarning
 from collections import OrderedDict
 from copy import deepcopy
 from .AsmCaps import CACHED_ASM_CAPS
@@ -46,12 +46,6 @@ class DeveloperWarning(Warning):
 
     This warning can be safely ignored when running any Tensile applications as a user.
     """
-
-def showwarning(message, category, filename, lineno, file=None, line=None):
-    msg = f"{category.__name__}: {message}"
-    if TENSILE_TERM_COLORS:
-        msg = f"[yellow]{msg}[/yellow]"
-    print(msg)
 
 warnings.showwarning = showwarning
 

--- a/Tensile/CustomKernels.py
+++ b/Tensile/CustomKernels.py
@@ -23,6 +23,7 @@
 ################################################################################
 
 from .Common import globalParameters
+from Tensile.Utilities.ConditionalImports import yamlLoader
 
 import yaml
 
@@ -60,6 +61,6 @@ def getCustomKernelConfigAndAssembly(name, directory=globalParameters["CustomKer
 def getCustomKernelConfig(name, directory=globalParameters["CustomKernelDirectory"]):
     rawConfig, _ = getCustomKernelConfigAndAssembly(name, directory)
     try:
-        return yaml.load(rawConfig, yaml.CSafeLoader)["custom.config"]
+        return yaml.load(rawConfig, yamlLoader)["custom.config"]
     except yaml.scanner.ScannerError as e:
         raise RuntimeError("Failed to read configuration for custom kernel: {0}\nDetails:\n{1}".format(name, e))

--- a/Tensile/GenerateSummations.py
+++ b/Tensile/GenerateSummations.py
@@ -33,6 +33,7 @@ import glob
 from shutil import copyfile
 from copy import deepcopy
 
+from .Utilities.ConditionalImports import yamlLoader
 from . import LibraryIO
 
 from . import ClientWriter
@@ -140,7 +141,7 @@ def GenerateSummations(userArgs):
         tensileLibraryFile = os.path.join(libPath, "library", "TensileLibrary.yaml")
 
         stream = open(tensileLibraryFile, "r")
-        tensileLibrary = yaml.load(stream, yaml.CSafeLoader)
+        tensileLibrary = yaml.load(stream, yamlLoader)
         stream.close()
 
         libSolutions = tensileLibrary["solutions"]

--- a/Tensile/LibraryIO.py
+++ b/Tensile/LibraryIO.py
@@ -27,6 +27,7 @@ from .SolutionStructs import Solution, ProblemSizes, ProblemType
 from . import __version__
 from . import Common
 from . import SolutionLibrary
+from .Utilities.ConditionalImports import yamlLoader, yamlDumper
 
 from typing import NamedTuple
 
@@ -74,7 +75,7 @@ def writeYAML(filename, data, **kwargs):
         kwargs["default_flow_style"] = None
 
     with open(filename, "w") as f:
-        yaml.dump(data, f, yaml.CSafeDumper, **kwargs)
+        yaml.dump(data, f, yamlDumper, **kwargs)
 
 
 def writeMsgPack(filename, data):
@@ -109,7 +110,7 @@ def writeSolutions(filename, problemSizes, solutions, cache=False):
                 #FIXME-problem, this ignores strides:
                 f.write("  - Exact: {}\n".format(problemExact))
 
-        yaml.dump(solutionStates, f, yaml.CSafeDumper, default_flow_style=None)
+        yaml.dump(solutionStates, f, yamlDumper, default_flow_style=None)
 
 
 ###############################
@@ -118,7 +119,7 @@ def writeSolutions(filename, problemSizes, solutions, cache=False):
 def readYAML(filename):
     """Reads and returns YAML data from file."""
     with open(filename, "r") as f:
-        data = yaml.load(f, yaml.CSafeLoader)
+        data = yaml.load(f, yamlLoader)
     return data
 
 

--- a/Tensile/TensileCreateLib/ParseArguments.py
+++ b/Tensile/TensileCreateLib/ParseArguments.py
@@ -25,7 +25,7 @@
 import os
 import warnings
 
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional
 from argparse import ArgumentParser, Action
 
 from ..Common import architectureMap
@@ -46,7 +46,7 @@ def splitExtraParameters(par):
     return (key, value)
 
 
-def parseArguments(input: List[str] | None = None) -> Dict[str, Any]:
+def parseArguments(input: Optional[List[str]] = None) -> Dict[str, Any]:
     """Parse command line arguments for TensileCreateLibrary.
 
     Args:

--- a/Tensile/TensileMergeLibrary.py
+++ b/Tensile/TensileMergeLibrary.py
@@ -24,6 +24,7 @@
 
 from .SolutionStructs import Solution
 from .Common import printExit, restoreDefaultGlobalParameters, assignGlobalParameters, ensurePath
+from .Utilities.ConditionalImports import yamlDumper
 from . import LibraryIO
 
 from copy import deepcopy
@@ -402,7 +403,7 @@ def avoidRegressions(originalDir, incrementalDir, outputPath, forceMerge, trimSi
         updateSizesAndSols(origData, mergedLogic)
 
         with open(os.path.join(outputPath, basename), "w") as outFile:
-            yaml.dump(origData, outFile, yaml.CSafeDumper, default_flow_style=None)
+            yaml.dump(origData, outFile, yamlDumper, default_flow_style=None)
         msg("File written to", os.path.join(outputPath, basename))
         msg("------------------------------")
 

--- a/Tensile/Tests/extended/convolution_config/YamlBuilder/YamlBuilder.py
+++ b/Tensile/Tests/extended/convolution_config/YamlBuilder/YamlBuilder.py
@@ -27,6 +27,8 @@ import subprocess
 import copy, operator, pytest
 from functools import reduce
 from Tensile.SolutionStructs import ConvProblem
+from Tensile.Utilities.ConditionalImports import yamlDumper
+
 import yaml
 
 
@@ -216,7 +218,7 @@ class YamlBuilder:
 
     def write(self, fname):
         with open(str(fname), "w") as f:
-            yaml.dump(self.doc, f, yaml.CSafeDumper, default_flow_style=None)
+            yaml.dump(self.doc, f, yamlDumper, default_flow_style=None)
 
     @classmethod
     def findAvailableArchs(self):

--- a/Tensile/Tests/unit/test_CustomKernels.py
+++ b/Tensile/Tests/unit/test_CustomKernels.py
@@ -27,6 +27,8 @@ import os
 from Tensile.CustomKernels import getCustomKernelConfig, getCustomKernelContents
 from Tensile.BenchmarkProblems import getCustomKernelSolutionObj
 from Tensile.Common import assignGlobalParameters
+from Tensile.Utilities.ConditionalImports import yamlLoader
+
 import yaml
 
 testKernelDir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "customKernels")
@@ -56,7 +58,7 @@ WorkGroup: [  8, 16,  1 ]
 DepthU: 8
 VectorWidth: 4
 AssertSizeEqual: {3: 512}
-AssertSizeMultiple: {0: 128, 1: 128}""", yaml.CSafeLoader
+AssertSizeMultiple: {0: 128, 1: 128}""", yamlLoader
 )
 
 # TODO when more custom kernels have been added - expand these lists

--- a/Tensile/Tests/unit/test_LibraryIO.py
+++ b/Tensile/Tests/unit/test_LibraryIO.py
@@ -29,6 +29,8 @@ import yaml
 
 from Tensile.__init__ import __version__
 import Tensile.LibraryIO as LibraryIO
+from Tensile.Utilities.ConditionalImports import yamlLoader
+
 
 # string literals for testing
 # list format
@@ -161,18 +163,18 @@ def createLibraryLogicList(arch_str, suffix_str, fp16AltImpl, fp16AltImplRound):
     sol0["ProblemType"] = problemType
 
     # other components
-    prefixData = yaml.load(version_l + arch_str, yaml.CSafeLoader)
-    sizeData = yaml.load(sizes, yaml.CSafeLoader)
-    suffixData = yaml.load(suffix_str, yaml.CSafeLoader)
+    prefixData = yaml.load(version_l + arch_str, yamlLoader)
+    sizeData = yaml.load(sizes, yamlLoader)
+    suffixData = yaml.load(suffix_str, yamlLoader)
 
     # handle fp16AltImpl and combine
     rv = prefixData + [problemType] + [[sol0, sol1]] + sizeData + suffixData
     if fp16AltImpl:
-        fp16AltData = yaml.load(fp16AltImpl_l, yaml.CSafeLoader)
+        fp16AltData = yaml.load(fp16AltImpl_l, yamlLoader)
         rv += fp16AltData
 
     if fp16AltImplRound:
-        fp16AltRoundData = yaml.load(fp16AltImplRound_l, yaml.CSafeLoader)
+        fp16AltRoundData = yaml.load(fp16AltImplRound_l, yamlLoader)
         rv += fp16AltRoundData
 
     return rv
@@ -203,18 +205,18 @@ def createLibraryLogicDict(arch_str, suffix_str, lib_str, fp16AltImpl_str, fp16A
     sol0["ProblemType"] = problemType
 
     # other components
-    prefixData = yaml.load(version_d + arch_str, yaml.CSafeLoader)
-    libData = yaml.load(lib_str, yaml.CSafeLoader)
-    suffixData = yaml.load(suffix_str, yaml.CSafeLoader)
+    prefixData = yaml.load(version_d + arch_str, yamlLoader)
+    libData = yaml.load(lib_str, yamlLoader)
+    suffixData = yaml.load(suffix_str, yamlLoader)
 
     # handle fp16AltImpl and combine
     fp16Data = {}
     if fp16AltImpl_str is not None:
-        fp16Data = yaml.load(fp16AltImpl_str, yaml.CSafeLoader)
+        fp16Data = yaml.load(fp16AltImpl_str, yamlLoader)
 
     fp16RoundData = {}
     if fp16AltImplRound_str is not None:
-        fp16RoundData = yaml.load(fp16AltImplRound_str, yaml.CSafeLoader)
+        fp16RoundData = yaml.load(fp16AltImplRound_str, yamlLoader)
 
     data = {**prefixData, **libData, **suffixData, **fp16Data, **fp16RoundData}
     data["ProblemType"] = problemType

--- a/Tensile/Tests/unit/test_TensileCreateLibrary.py
+++ b/Tensile/Tests/unit/test_TensileCreateLibrary.py
@@ -32,6 +32,7 @@ import Tensile.Common as Common
 import Tensile.ClientWriter as ClientWriter
 import Tensile.SolutionStructs as SolutionStructs
 import Tensile.SolutionLibrary as SolutionLibrary
+from Tensile.Utilities.ConditionalImports import yamlLoader
 import yaml
 import contextlib
 import uuid
@@ -110,7 +111,7 @@ def test_WriteClientLibraryFromSolutions(tmpdir):
         stream = open(tensileYamlFilePath, "r")
     except IOError:
         mylogger.error("Cannot open file: %s" % tensileYamlFilePath)
-    config = yaml.load(stream, yaml.CSafeLoader)
+    config = yaml.load(stream, yamlLoader)
     stream.close()
     actualSolutions = config["solutions"]
 
@@ -124,7 +125,7 @@ def test_WriteClientLibraryFromSolutions(tmpdir):
         stream = open(metadataYamlFilePath, "r")
     except IOError:
         mylogger.error("Cannot open file: %s" % metadataYamlFilePath)
-    metadata = yaml.load(stream, yaml.CSafeLoader)
+    metadata = yaml.load(stream, yamlLoader)
     stream.close()
     actualProblemType = metadata["ProblemType"]
 

--- a/Tensile/Tests/unit/test_mergeLogic.py
+++ b/Tensile/Tests/unit/test_mergeLogic.py
@@ -23,6 +23,8 @@
 ################################################################################
 
 from Tensile.Utilities.merge import cmpHelper, fixSizeInconsistencies, removeUnusedKernels, mergeLogic
+from Tensile.Utilities.ConditionalImports import yamlLoader
+
 import yaml, pytest
 
 # the merge scripts does not differentiate solutions based on index or name
@@ -220,7 +222,7 @@ def checkUniqueSolution(solutionPool):
   (notTrimmedSize, [[1024,1024,1,1024],[128,128,1,128]])
   ])
 def test_fixSizeInconsistencies(sizes, expected):
-  data = yaml.load(sizes, yaml.CSafeLoader)
+  data = yaml.load(sizes, yamlLoader)
   data_ = fixSizeInconsistencies(data[0], "dummy")
 
   for [size, [_,_]], expected_ in zip(data_[0], expected):
@@ -229,7 +231,7 @@ def test_fixSizeInconsistencies(sizes, expected):
 @pytest.mark.parametrize("input,expectedNumKernelRemoved", [(baseLogic, 1),
                                                             (incLogic, 0)])
 def test_removeUnusedKernels(input, expectedNumKernelRemoved):
-  data = yaml.load(input, yaml.CSafeLoader)
+  data = yaml.load(input, yamlLoader)
   dataFiltered, numKernelRemoved = removeUnusedKernels(data)
 
   # test if number of solution removed is correct
@@ -265,8 +267,8 @@ def test_removeUnusedKernels(input, expectedNumKernelRemoved):
   ["InUseForSize256", "InUseForSize128or64", "InUseForSize128or64"]),
 ])
 def test_mergeLogic(baseLogic, incLogic, expectedStats, expectedSizes, expectedSolutions):
-  baseData = yaml.load(baseLogic, yaml.CSafeLoader)
-  incData = yaml.load(incLogic, yaml.CSafeLoader)
+  baseData = yaml.load(baseLogic, yamlLoader)
+  incData = yaml.load(incLogic, yamlLoader)
 
   mergedData, *stats = mergeLogic(baseData, incData, False)
 
@@ -287,7 +289,7 @@ def test_mergeLogic(baseLogic, incLogic, expectedStats, expectedSizes, expectedS
 
 @pytest.mark.parametrize("input,expected", [(uniqueSolution, True), (notUniqueSolution, False)])
 def test_checkUniqueSolution(input, expected):
-  data = yaml.load(input, yaml.CSafeLoader)
+  data = yaml.load(input, yamlLoader)
   assert checkUniqueSolution(data[5]) == expected
 
 @pytest.mark.parametrize("baseLogic, incLogic, expectedSizesYaml, expectedSolutions", [
@@ -302,9 +304,9 @@ def test_checkUniqueSolution(input, expected):
    mfmaMergeResNotMatchingMFMA, ["MFMA_base", "VALU_base", "MFMA_inc", "VALU_inc"])
 ])
 def test_mfmaMergeLogic(baseLogic, incLogic, expectedSizesYaml, expectedSolutions):
-  baseData      = yaml.load(baseLogic, yaml.CSafeLoader)
-  incData       = yaml.load(incLogic,  yaml.CSafeLoader)
-  expectedSizes = yaml.load(expectedSizesYaml, yaml.CSafeLoader)[0]
+  baseData      = yaml.load(baseLogic, yamlLoader)
+  incData       = yaml.load(incLogic,  yamlLoader)
+  expectedSizes = yaml.load(expectedSizesYaml, yamlLoader)[0]
 
   mergedData, _, _, _ = mergeLogic(baseData, incData, False, True, True)
 

--- a/Tensile/Tests/yaml_only/test_config.py
+++ b/Tensile/Tests/yaml_only/test_config.py
@@ -29,6 +29,8 @@ import yaml
 
 from Tensile import Tensile
 from Tensile import DataType
+from Tensile.Utilities.ConditionalImports import yamlLoader
+
 
 ################################################################################
 # Locate Executables
@@ -100,7 +102,7 @@ def configMarks(filepath, rootDir, availableArchs):
 
     try:
         with open(filepath) as f:
-            doc = yaml.load(f, yaml.CSafeLoader)
+            doc = yaml.load(f, yamlLoader)
     except yaml.parser.ParserError:
         marks.append(pytest.mark.syntax_error)
         return marks

--- a/Tensile/Utilities/ConditionalImports.py
+++ b/Tensile/Utilities/ConditionalImports.py
@@ -1,16 +1,10 @@
 TENSILE_TERM_COLORS: bool = False
 try:
-    from rich import print as _print
+    from rich import print as print
     TENSILE_TERM_COLORS = True
 except ImportError:
-    _print = print
+    print = print
 
-
-def showwarning(message, category, filename, lineno, file=None, line=None):
-    msg = f"{category.__name__}: {message}"
-    if TENSILE_TERM_COLORS:
-        msg = f"[yellow]{msg}[/yellow]"
-    _print(msg)
 
 
 try:

--- a/Tensile/Utilities/ConditionalImports.py
+++ b/Tensile/Utilities/ConditionalImports.py
@@ -2,10 +2,18 @@ import warnings
 
 TENSILE_TERM_COLORS: bool = False
 try:
-    from rich import print
+    from rich import print as _print
     TENSILE_TERM_COLORS = True
 except ImportError:
-    pass
+    _print = print
+
+
+def showwarning(message, category, filename, lineno, file=None, line=None):
+    msg = f"{category.__name__}: {message}"
+    if TENSILE_TERM_COLORS:
+        msg = f"[yellow]{msg}[/yellow]"
+    _print(msg)
+
 
 try:
     from yaml import CSafeLoader as yamlLoader

--- a/Tensile/Utilities/ConditionalImports.py
+++ b/Tensile/Utilities/ConditionalImports.py
@@ -1,5 +1,3 @@
-import warnings
-
 TENSILE_TERM_COLORS: bool = False
 try:
     from rich import print as _print

--- a/Tensile/Utilities/ConditionalImports.py
+++ b/Tensile/Utilities/ConditionalImports.py
@@ -1,5 +1,12 @@
 import warnings
 
+TENSILE_TERM_COLORS: bool = False
+try:
+    from rich import print
+    TENSILE_TERM_COLORS = True
+except ImportError:
+    pass
+
 try:
     from yaml import CSafeLoader as yamlLoader
 except ImportError:

--- a/Tensile/Utilities/ConditionalImports.py
+++ b/Tensile/Utilities/ConditionalImports.py
@@ -10,11 +10,9 @@ except ImportError:
 try:
     from yaml import CSafeLoader as yamlLoader
 except ImportError:
-    warnings.warn("Couldn't import CSafeLoader backend, defaulting to slower SafeDumper")
     from yaml import SafeLoader as yamlLoader
 
 try:
     from yaml import CSafeDumper as yamlDumper 
 except ImportError:
-    warnings.warn("Couldn't import CSafeDumper backend, defaulting to slower SafeDumper")
     from yaml import SafeDumper as yamlDumper

--- a/Tensile/Utilities/ConditionalImports.py
+++ b/Tensile/Utilities/ConditionalImports.py
@@ -1,0 +1,13 @@
+import warnings
+
+try:
+    from yaml import CSafeLoader as yamlLoader
+except ImportError:
+    warnings.warn("Couldn't import CSafeLoader backend, defaulting to slower SafeDumper")
+    from yaml import SafeLoader as yamlLoader
+
+try:
+    from yaml import CSafeDumper as yamlDumper 
+except ImportError:
+    warnings.warn("Couldn't import CSafeDumper backend, defaulting to slower SafeDumper")
+    from yaml import SafeDumper as yamlDumper

--- a/Tensile/Utilities/archive/merge_rocblas_yaml_files.py
+++ b/Tensile/Utilities/archive/merge_rocblas_yaml_files.py
@@ -26,6 +26,7 @@ from __future__ import print_function
 import os
 import sys
 import argparse
+from Tensile.Utilities.ConditionalImports import yamlLoader, yamlDumper
 
 HR = "################################################################################"
 
@@ -65,7 +66,7 @@ class LibraryLogic:
         stream = open(filename, "r")
       except IOError:
         printExit("Cannot open file: %s" % filename )
-      data = yaml.load(stream, yaml.CSafeLoader)
+      data = yaml.load(stream, yamlLoader)
 
       if isinstance(data, list):
 
@@ -243,7 +244,7 @@ class LibraryLogic:
     else:
       try:
         stream = open(filename, "w")
-        yaml.dump(data, stream, yaml.CSafeDumper, default_flow_style=None)
+        yaml.dump(data, stream, yamlDumper, default_flow_style=None)
         stream.close()
       except IOError:
         printExit("Cannot open file: %s" % filename)

--- a/Tensile/Utilities/merge.py
+++ b/Tensile/Utilities/merge.py
@@ -22,6 +22,8 @@
 #
 ################################################################################
 
+from Tensile.Utilities.ConditionalImports import yamlLoader, yamlDumper
+
 import yaml
 import os
 import sys
@@ -134,7 +136,7 @@ def loadData(filename):
         print("Cannot open file: ", filename)
         sys.stdout.flush()
         sys.exit(-1)
-    data = yaml.load(stream, yaml.CSafeLoader)
+    data = yaml.load(stream, yamlLoader)
     return data
 
 # this is for complying the behavior of legacy merge script, where incremental logic
@@ -390,7 +392,7 @@ def avoidRegressions(originalDir, incrementalDir, outputPath, forceMerge, trimSi
         msg(stats[0], "size(s) and", stats[1], "kernel(s) added,", stats[2], "kernel(s) removed")
 
         with open(os.path.join(outputPath, basename), "w") as outFile:
-            yaml.dump(mergedData, outFile, yaml.CSafeDumper, default_flow_style=None)
+            yaml.dump(mergedData, outFile, yamlDumper, default_flow_style=None)
         msg("File written to", os.path.join(outputPath, basename))
         msg("------------------------------")
 
@@ -434,7 +436,7 @@ def mergePartialLogics(partialLogicFilePaths, outputDir, forceMerge, trimSize=Tr
     baseFileName = os.path.basename(baseLogicFile)
     outputFilePath = os.path.join(outputDir, baseFileName)
     with open(outputFilePath, "w") as outFile:
-        yaml.dump(baseLogicData, outFile, yaml.CSafeDumper, default_flow_style=None)
+        yaml.dump(baseLogicData, outFile, yamlDumper, default_flow_style=None)
     msg("File written to", outputFilePath)
     msg("------------------------------")
 

--- a/tox.ini
+++ b/tox.ini
@@ -61,6 +61,7 @@ commands =
 
 [flake8]
 exclude = .git,build*,dist,.cache,*~
+per-file-ignores = Tensile/Utilities/ConditionalImports.py:F401
 max-line-length = 132
 ignore =
      # All E class violations are errors reported by pycodestyle

--- a/tuning/automation/ConvertToEfficiency.py
+++ b/tuning/automation/ConvertToEfficiency.py
@@ -28,6 +28,7 @@ import yaml
 import sys
 sys.path.append(os.path.join(os.path.dirname(sys.path[0]),'..','Tensile'))
 from DataType import DataType
+from Tensile.Utilities.ConditionalImports import yamlLoader, yamlDumper
 
 def parseArgs():
     argParser = argparse.ArgumentParser()
@@ -76,7 +77,7 @@ def main():
     mfmaKey = "mfma" if args.mfma else "non_mfma"
 
     with open(args.specs) as y:
-        specs = yaml.load(y, yaml.CSafeLoader)
+        specs = yaml.load(y, yamlLoader)
 
     try:
         os.makedirs(args.outDir)
@@ -89,7 +90,7 @@ def main():
             print(f)
             with open(f) as y:
 
-                data = yaml.load(y, yaml.CSafeLoader)
+                data = yaml.load(y, yamlLoader)
 
                 sched = data[1]
                 if args.x:
@@ -127,7 +128,7 @@ def main():
             outFile = os.path.join(args.outDir, fName)
 
             with open(outFile, "w") as y:
-                yaml.dump(data, y, yaml.CSafeDumper, default_flow_style=None)
+                yaml.dump(data, y, yamlDumper, default_flow_style=None)
 
 if __name__ == "__main__":
     main()

--- a/tuning/automation/RemoveSizes.py
+++ b/tuning/automation/RemoveSizes.py
@@ -26,6 +26,8 @@
 # Usage:
 # $ python3 RemoveSizes.py [-v] <input lib logic> <output lib logic> <csv file with sizes>
 
+from Tensile.Utilities.ConditionalImports import yamlLoader, yamlDumper
+
 import argparse
 import csv
 import yaml
@@ -55,7 +57,7 @@ def main():
         print("Sizes File  : " + args.sizeList)
 
     with open(args.inLogic) as inFile:
-        logicData = yaml.load(inFile, yaml.CSafeLoader)
+        logicData = yaml.load(inFile, yamlLoader)
 
     mapping = logicData[7]
     if args.verbose:
@@ -82,7 +84,7 @@ def main():
         print("Final size count = {}".format(len(mapping)))
 
     with open(args.outLogic, "w") as outFile:
-        yaml.dump(logicData, outFile, yaml.CSafeDumper, default_flow_style=None, sort_keys=False, width=5000)
+        yaml.dump(logicData, outFile, yamlDumper, default_flow_style=None, sort_keys=False, width=5000)
 
     if args.verbose:
         print("Done writing new logic file")

--- a/tuning/automation/TuningConfiguration.py
+++ b/tuning/automation/TuningConfiguration.py
@@ -27,6 +27,8 @@ import os
 import sys
 import argparse
 
+from Tensile.Utilities.ConditionalImports import yamlLoader, yamlDumper
+
 
 def printExit(message):
   print ("Tensile::FATAL: %s" % message)
@@ -120,7 +122,7 @@ class TuningConfiguration(object):
             except IOError:
                 printExit("Cannot open file: %s" % filename )
 
-            data = yaml.load(stream, yaml.CSafeLoader)
+            data = yaml.load(stream, yamlLoader)
 
             if CONST.GlobalParameters in data:
                 self.__globalParameters = data[CONST.GlobalParameters]
@@ -188,17 +190,17 @@ class TuningConfiguration(object):
 
             if self.globalParameters:
                 dataGlobal[CONST.GlobalParameters] = self.globalParameters
-                yaml.dump(dataGlobal, stream, yaml.CSafeDumper, default_flow_style=None, width=1024)
+                yaml.dump(dataGlobal, stream, yamlDumper, default_flow_style=None, width=1024)
                 stream.flush()
 
             if self.benchmarkProblems:
                 dataBenchmark[CONST.BenchmarkProblems] = self.benchmarkProblems
-                yaml.dump(dataBenchmark, stream, yaml.CSafeDumper, default_flow_style=None)
+                yaml.dump(dataBenchmark, stream, yamlDumper, default_flow_style=None)
                 stream.flush()
 
             if self.libraryLogic:
                 dataLibraryLogic[CONST.LibraryLogic] = self.libraryLogic
-                yaml.dump(dataLibraryLogic, stream, yaml.CSafeDumper, default_flow_style=None, width=1024)
+                yaml.dump(dataLibraryLogic, stream, yamlDumper, default_flow_style=None, width=1024)
                 stream.flush()
 
             if self.libraryClient:

--- a/tuning/automation/rocblas-benchInputCreator.py
+++ b/tuning/automation/rocblas-benchInputCreator.py
@@ -44,6 +44,8 @@ import os
 import yaml
 import math
 
+from Tensile.Utilities.ConditionalImports import yamlLoader, yamlDumper
+
 typeIndexToName = {0: "f32_r", 1: "f64_r", 2: "f32_c", 3: "f64_c", 4: "f16_r", 5: "i8_r", 6: "i32_r", 7: "bf16_r", 8: "i8_r", 10: "f8_r", 11: "bf8_r", 12: "f8b8", 13: "b8f8"}
 
 def parseArgs():
@@ -180,7 +182,7 @@ def dumpYaml(outDir, outputfile,postfix, content):
     name = outputfile+postfix
     benchPath = os.path.join(outDir, name)
     with open(benchPath, "w") as f:
-        yaml.dump(content, f, yaml.CSafeDumper, default_flow_style=None, sort_keys=False, width=5000)
+        yaml.dump(content, f, yamlDumper, default_flow_style=None, sort_keys=False, width=5000)
         f.write(f"# End of {name} \n")
 
 def createYaml(args, outputfile, problem, sizeMappings, verify):
@@ -327,7 +329,7 @@ def main():
         print(f" working on {output}")
         yamlName = os.path.join(args.libLogic,libname)
         with open(yamlName) as f:
-            logicData = yaml.load(f, yaml.CSafeLoader)
+            logicData = yaml.load(f, yamlLoader)
 
         try:
             os.makedirs(args.outDir)

--- a/tuning/automation/rocblas-parser.py
+++ b/tuning/automation/rocblas-parser.py
@@ -32,6 +32,9 @@ import os
 import argparse
 import yaml
 
+from Tensile.Utilities.ConditionalImports import yamlDumper
+
+
 def parseBenchCofnig():
     argParser = argparse.ArgumentParser()
 
@@ -355,7 +358,7 @@ def create_rocBLAS_bench(benchFile, matrices,verify,initialization):
         # write output
         with open(benchFile, "w") as f:
             if len(bench) > 0:
-                yaml.dump(bench, f, yaml.CSafeDumper, default_flow_style=None, sort_keys=False, width=5000)
+                yaml.dump(bench, f, yamlDumper, default_flow_style=None, sort_keys=False, width=5000)
 
 def main():
     args = parseBenchCofnig()    


### PR DESCRIPTION
This is a patch for resolving imports for *rich* and *CSafeLoader/CSafeDumper*---Python and OS-level dependencies, respectively.

Testing has demonstrated that, while Ubuntu 20.04 onwards comes equipped with appropriate libyaml development packages, RHEL and SLES don't necessarily. The changes in this PR add a *ConditionalImports.py* file so that that new dependencies can be added with stable fallbacks.

These changes are intended as a stopgap; a long-term solution may be to integrate the required dependencies into the CI staging images (in which case the changes in this PR may be reverted), if this is not plausible, then documenting steps for users to setup appropriate dependencies will be important.