### PR TITLE
Improve rocBLAS build output

### DIFF
--- a/HostLibraryTests/configs/ConvertYAML.py
+++ b/HostLibraryTests/configs/ConvertYAML.py
@@ -43,7 +43,7 @@ def merge_libraries(args):
 
     masterLibrary = MasterSolutionLibrary.FromOriginalState(data)
 
-    for inFile in Utils.tqdm(inFiles[1:]):
+    for inFile in Utils.tqdm(inFiles[1:], msg="Merge libraries"):
         with open(inFile) as inf:
             data = yaml.load(inf)
         newLibrary = MasterSolutionLibrary.FromOriginalState(data)
@@ -89,7 +89,7 @@ def convert_one(args):
 
 if __name__ == "__main__":
 
-    for i in Utils.tqdm(itertools.chain([1,2,3], [4,5,6])): time.sleep(1)
+    for i in Utils.tqdm(itertools.chain([1,2,3], [4,5,6]), msg="Converting YAML"): time.sleep(1)
 
     merge_libraries(sys.argv[1:])
 

--- a/HostLibraryTests/configs/ConvertYAML.py
+++ b/HostLibraryTests/configs/ConvertYAML.py
@@ -43,7 +43,7 @@ def merge_libraries(args):
 
     masterLibrary = MasterSolutionLibrary.FromOriginalState(data)
 
-    for inFile in Utils.tqdm(inFiles[1:], msg="Merge libraries"):
+    for inFile in Utils.tqdm(inFiles[1:], desc="Merge libraries"):
         with open(inFile) as inf:
             data = yaml.load(inf)
         newLibrary = MasterSolutionLibrary.FromOriginalState(data)
@@ -89,7 +89,7 @@ def convert_one(args):
 
 if __name__ == "__main__":
 
-    for i in Utils.tqdm(itertools.chain([1,2,3], [4,5,6]), msg="Converting YAML"): time.sleep(1)
+    for i in Utils.tqdm(itertools.chain([1,2,3], [4,5,6]), desc="Converting YAML"): time.sleep(1)
 
     merge_libraries(sys.argv[1:])
 

--- a/Tensile/BenchmarkProblems.py
+++ b/Tensile/BenchmarkProblems.py
@@ -126,7 +126,7 @@ def writeBenchmarkFiles(stepBaseDir, solutions, problemSizes, \
     kernelHelperNames = set()
 
     # get unique kernels and kernel helpers
-    for solution in Utils.tqdm(solutions, msg="Finding unique solutions"):
+    for solution in Utils.tqdm(solutions, desc="Finding unique solutions"):
         solutionKernels = solution.getKernels()
         for kernel in solutionKernels:
             kName = Solution.getNameFull(kernel)

--- a/Tensile/BenchmarkProblems.py
+++ b/Tensile/BenchmarkProblems.py
@@ -126,7 +126,7 @@ def writeBenchmarkFiles(stepBaseDir, solutions, problemSizes, \
     kernelHelperNames = set()
 
     # get unique kernels and kernel helpers
-    for solution in Utils.tqdm(solutions, "Finding unique solutions"):
+    for solution in Utils.tqdm(solutions, msg="Finding unique solutions"):
         solutionKernels = solution.getKernels()
         for kernel in solutionKernels:
             kName = Solution.getNameFull(kernel)

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -2576,45 +2576,6 @@ def ClientExecutionLock():
 def listToInitializer(l):
   return "{" + ','.join(map(str, l)) + "}"
 
-################################################################################
-# Progress Bar Printing
-# prints "||||" up to width
-################################################################################
-class ProgressBar:
-  def __init__(self, maxValue, width=80):
-    self.char = '|'
-    self.maxValue = maxValue
-    self.width = width
-    self.maxTicks = self.width - 7
-
-
-    self.priorValue = 0
-    self.fraction = 0
-    self.numTicks = 0
-    self.createTime = time.time()
-
-  def increment(self, value=1):
-    self.update(self.priorValue+value)
-
-  def update(self, value):
-    currentFraction = 1.0 * value / self.maxValue
-    currentNumTicks = int(currentFraction * self.maxTicks)
-    if currentNumTicks > self.numTicks:
-      self.numTicks = currentNumTicks
-      self.fraction = currentFraction
-      self.printStatus()
-    self.priorValue = value
-
-  def printStatus(self):
-    sys.stdout.write("\r")
-    sys.stdout.write("[%-*s] %3d%%" \
-        % (self.maxTicks, self.char*self.numTicks, self.fraction*100) )
-    if self.numTicks == self.maxTicks:
-      stopTime = time.time()
-      sys.stdout.write(" (%-.1f secs elapsed)\n"%(stopTime-self.createTime))
-    sys.stdout.flush()
-
-  def finish(self): pass
 
 from copy import copy
 class Backup:

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -1986,7 +1986,7 @@ def tPrint(verbosity: int, arg) -> None:
         print(arg)
         sys.stdout.flush()
 
-def printWarning(message: str, category: type[Warning]=DeveloperWarning):
+def printWarning(message: str, category=UserWarning):
   warnings.warn(message, category)
   sys.stdout.flush()
 
@@ -2118,7 +2118,7 @@ def GetAsmCaps(isaVersion):
                          (compilerVer[0] == 5 and compilerVer[1] <= 2) 
       
     if not derivedAsmCaps["SupportedISA"] and CACHED_ASM_CAPS[isaVersion]["SupportedISA"]:
-      printWarning("Architecture {} not supported by ROCm {}".format(isaVersion, globalParameters['HipClangVersion']))
+      printWarning("Architecture {} not supported by ROCm {}".format(isaVersion, globalParameters['HipClangVersion']), DeveloperWarning)
       ignoreCacheCheck = True
 
     # check if derived caps matches asm cap cache
@@ -2469,7 +2469,7 @@ def assignGlobalParameters( config ):
   for key in config:
     value = config[key]
     if key not in globalParameters:
-      printWarning("Global parameter %s = %s unrecognized." % ( key, value ))
+      printWarning("Global parameter %s = %s unrecognized." % ( key, value ), DeveloperWarning)
     globalParameters[key] = value
 
 def setupRestoreClocks():

--- a/Tensile/LibraryLogic.py
+++ b/Tensile/LibraryLogic.py
@@ -253,7 +253,7 @@ class LogicAnalyzer:
     for solutionGroupIdx in range(0, len(solutionsList)):
       solutionGroup = solutionsList[solutionGroupIdx]
       totalSolutions += len(solutionGroup)
-    progressBar = Utils.ProgressBar(totalSolutions, msg="LogicAnalyzer")
+    progressBar = Utils.ProgressBar(totalSolutions, desc="LogicAnalyzer")
     for solutionGroupIdx in range(0, len(solutionsList)):
       solutionGroup = solutionsList[solutionGroupIdx]
       self.numSolutionsPerGroup.append(len(solutionGroup))

--- a/Tensile/LibraryLogic.py
+++ b/Tensile/LibraryLogic.py
@@ -23,8 +23,9 @@
 ################################################################################
 
 from .Common import tPrint, HR, printExit, defaultAnalysisParameters, globalParameters, \
-  setWorkingPath, popWorkingPath, assignParameterWithDefault, startTime, ProgressBar, printWarning
+  setWorkingPath, popWorkingPath, assignParameterWithDefault, startTime, printWarning
 from .SolutionStructs import Solution
+from . import Utils
 from . import LibraryIO
 from . import SolutionSelectionLibrary
 
@@ -252,7 +253,7 @@ class LogicAnalyzer:
     for solutionGroupIdx in range(0, len(solutionsList)):
       solutionGroup = solutionsList[solutionGroupIdx]
       totalSolutions += len(solutionGroup)
-    progressBar = ProgressBar(totalSolutions)
+    progressBar = Utils.ProgressBar(totalSolutions, msg="LogicAnalyzer")
     for solutionGroupIdx in range(0, len(solutionsList)):
       solutionGroup = solutionsList[solutionGroupIdx]
       self.numSolutionsPerGroup.append(len(solutionGroup))

--- a/Tensile/Parallel.py
+++ b/Tensile/Parallel.py
@@ -80,18 +80,15 @@ def ParallelMap(function: Callable, objects: Any, message: str="", enable: bool=
     from . import Utils
     threadCount = CPUThreadCount(enable)
     
-    if threadCount <= 1 and globalParameters["ShowProgressBar"]:
-      # Provide a progress bar for single-threaded operation.
+    if threadCount <= 1:
       return list(map(lambda objs: function(*objs), Utils.tqdm(objects, desc=message)))
-    
-    message += f": {threadCount} threads"
-    try:
-      message += f", {len(objects)} tasks"
-    except TypeError: pass
-    
-    pcall = pcallWithGlobalParamsMultiArg if multiArg else pcallWithGlobalParamsSingleArg
+        
     inputs = list(zip(objects, itertools.repeat(globalParameters)))
+    message += f": {threadCount} threads, {len(inputs)} tasks"
+
     pargs = Utils.tqdm(inputs, desc=message)
+    pcall = pcallWithGlobalParamsMultiArg if multiArg else pcallWithGlobalParamsSingleArg
+
     rv = Parallel(n_jobs=threadCount)(delayed(pcall)(function, a, params) for a, params in pargs)
     
     return rv

--- a/Tensile/Parallel.py
+++ b/Tensile/Parallel.py
@@ -24,7 +24,6 @@
 
 import itertools
 import os
-import sys
 
 from joblib import Parallel, delayed
 
@@ -72,13 +71,14 @@ def ParallelMap(function, objects, message="", enable=True, multiArg=True, verbo
     # Provide a progress bar for single-threaded operation.
     return list(map(lambda objs: function(*objs), Utils.tqdm(objects, msg=message)))
   
-  message += f" with {threadCount} threads"
+  message += f": {threadCount} threads"
   try:
-    message += f" for {len(objects)} tasks"
+    message += f", {len(objects)} tasks"
   except TypeError: pass
   
   pcall = pcallWithGlobalParamsMultiArg if multiArg else pcallWithGlobalParamsSingleArg
-  pargs = Utils.tqdm(zip(objects, itertools.repeat(globalParameters)), msg=message)
+  inputs = list(zip(objects, itertools.repeat(globalParameters)))
+  pargs = Utils.tqdm(inputs, msg=message)
   rv = Parallel(n_jobs=threadCount, verbose=verbose)(delayed(pcall)(function, a, params) for a, params in pargs)
   
   return rv

--- a/Tensile/Parallel.py
+++ b/Tensile/Parallel.py
@@ -77,7 +77,7 @@ def ParallelMap(function, objects, message="", enable=True, multiArg=True, verbo
   except TypeError: pass
   
   pcall = pcallWithGlobalParamsMultiArg if multiArg else pcallWithGlobalParamsSingleArg
-  inputs = list(zip(objects, itertools.repeat(globalParameters)))
+  inputs = zip(objects, itertools.repeat(globalParameters))
   pargs = Utils.tqdm(inputs, msg=message)
   rv = Parallel(n_jobs=threadCount, verbose=verbose)(delayed(pcall)(function, a, params) for a, params in pargs)
   

--- a/Tensile/Parallel.py
+++ b/Tensile/Parallel.py
@@ -82,7 +82,7 @@ def ParallelMap(function: Callable, objects: Any, message: str="", enable: bool=
     
     if threadCount <= 1 and globalParameters["ShowProgressBar"]:
       # Provide a progress bar for single-threaded operation.
-      return list(map(lambda objs: function(*objs), Utils.tqdm(objects, desc=message, total=n)))
+      return list(map(lambda objs: function(*objs), Utils.tqdm(objects, desc=message)))
     
     message += f": {threadCount} threads"
     try:

--- a/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -1787,7 +1787,7 @@ namespace Tensile
             }
         }
 
-        return remainder >= get<1>(predictionCurve.back()) ? 0 : 1;
+        return remainder >= std::get<1>(predictionCurve.back()) ? 0 : 1;
     }
 
     size_t ContractionSolution::getSKGrid(Problem const&  problem,

--- a/Tensile/TensileCreateLib/ParseArguments.py
+++ b/Tensile/TensileCreateLib/ParseArguments.py
@@ -297,6 +297,8 @@ def parseArguments(input: List[str] | None = None) -> Dict[str, Any]:
     if args.GenerateSourcesAndExit:
         # Generated sources are preserved and go into output directory
         arguments["WorkingPath"] = arguments["OutputPath"]
+    if args.PrintLevel == 0:
+        warnings.filterwarnings("ignore")
 
     for k, v in args.GlobalParameters:
         arguments[k] = v

--- a/Tensile/TensileCreateLib/ParseArguments.py
+++ b/Tensile/TensileCreateLib/ParseArguments.py
@@ -28,7 +28,7 @@ import warnings
 from typing import Dict, Any, List
 from argparse import ArgumentParser, Action
 
-from ..Common import architectureMap
+from ..Common import architectureMap, DeveloperWarning
 
 
 class DeprecatedOption(Action):
@@ -298,7 +298,7 @@ def parseArguments(input: List[str] | None = None) -> Dict[str, Any]:
         # Generated sources are preserved and go into output directory
         arguments["WorkingPath"] = arguments["OutputPath"]
     if args.PrintLevel == 0:
-        warnings.filterwarnings("ignore")
+        warnings.filterwarnings("ignore", category=DeveloperWarning)
 
     for k, v in args.GlobalParameters:
         arguments[k] = v

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -244,7 +244,7 @@ def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile):
         archFlags = ["--offload-arch=" + arch for arch in cmdlineArchs]
 
         # needs to be fixed when Maneesh's change is made available
-        hipFlags = ["-D__HIP_HCC_COMPAT_MODE__=1", "-v"]
+        hipFlags = ["-D__HIP_HCC_COMPAT_MODE__=1"]
         hipFlags += (
             ["--genco"] if CxxCompiler == "hipcc" else ["--cuda-device-only", "-x", "hip", "-O3"]
         )

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -182,7 +182,7 @@ def getAssemblyCodeObjectFiles(kernels, kernelWriterAssembly, outputPath):
             for src, dst in (
                 zip(origCOFiles, newCOFiles)
                 if globalParameters["PrintLevel"] == 0
-                else Utils.tqdm(zip(origCOFiles, newCOFiles), "Copying code objects")
+                else Utils.tqdm(zip(origCOFiles, newCOFiles), msg="Copying code objects")
             ):
                 shutil.copyfile(src, dst)
             coFiles += newCOFiles
@@ -248,7 +248,6 @@ def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile):
         hipFlags += (
             ["--genco"] if CxxCompiler == "hipcc" else ["--cuda-device-only", "-x", "hip", "-O3"]
         )
-        hipFlags += ["-v"]
         # if CxxCompiler == "amdclang++":
         # hipFlags += ["-mllvm", "-amdgpu-early-inline-all=true", "-mllvm", "-amdgpu-function-calls=false"]
         hipFlags += ["-I", outputPath]
@@ -295,7 +294,6 @@ def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile):
         except subprocess.CalledProcessError as err:
             print(err.output)
             raise
-        # out = subprocess.check_call(compileArgs)
 
         # get hipcc version due to compatiblity reasons
         # If we aren't using hipcc what happens?
@@ -629,7 +627,7 @@ def filterProcessingErrors(
     keepKernels = []
     keepSolutions = []
     keepResults = []
-    for i, res in enumerate(results) if printLevel == 0 else Utils.tqdm(enumerate(results)):
+    for i, res in enumerate(results):
         err, _, _, _, _ = res
         if err != -2:
             keepKernels.append(kernels[i])
@@ -702,7 +700,7 @@ def writeKernels(
         itertools.repeat(kernelWriterSource),
         itertools.repeat(kernelWriterAssembly),
     )
-    results = Common.ParallelMap(processKernelSource, kIter, "Generating kernels")
+    results = Common.ParallelMap(processKernelSource, kIter, "Generating kernels", verbose=0)
     kernels, solutions, results = filterProcessingErrors(
         kernels, solutions, results, params["PrintLevel"], errorTolerant
     )
@@ -1312,7 +1310,7 @@ def generateLogicData(
         master solution library for all architectures.
     """
     libraries = parseLibraryLogicFiles(logicFiles)
-    logicList = libraries if not printLevel else Utils.tqdm(libraries, "Processing logic data")
+    logicList = libraries if not printLevel else Utils.tqdm(libraries, msg="Processing logic data")
     masterLibraries = makeMasterLibraries(logicList, separate)
     if separate:
         addFallback(masterLibraries)

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -248,6 +248,7 @@ def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile):
         hipFlags += (
             ["--genco"] if CxxCompiler == "hipcc" else ["--cuda-device-only", "-x", "hip", "-O3"]
         )
+        hipFlags += ["-v"]
         # if CxxCompiler == "amdclang++":
         # hipFlags += ["-mllvm", "-amdgpu-early-inline-all=true", "-mllvm", "-amdgpu-function-calls=false"]
         hipFlags += ["-I", outputPath]
@@ -288,12 +289,13 @@ def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile):
 
         tPrint(2, "hipcc:" + " ".join(compileArgs))
         # change to use  check_output to force windows cmd block util command finish
-        try:
-            out = subprocess.check_output(compileArgs, stderr=subprocess.STDOUT)
-            tPrint(3, out)
-        except subprocess.CalledProcessError as err:
-            print(err.output)
-            raise
+        # try:
+        #     out = subprocess.check_output(compileArgs, stderr=subprocess.STDOUT)
+        #     tPrint(3, out)
+        # except subprocess.CalledProcessError as err:
+        #     print(err.output)
+        #     raise
+        out = subprocess.check_call(compileArgs)
 
         # get hipcc version due to compatiblity reasons
         # If we aren't using hipcc what happens?

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -289,13 +289,13 @@ def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile):
 
         tPrint(2, "hipcc:" + " ".join(compileArgs))
         # change to use  check_output to force windows cmd block util command finish
-        # try:
-        #     out = subprocess.check_output(compileArgs, stderr=subprocess.STDOUT)
-        #     tPrint(3, out)
-        # except subprocess.CalledProcessError as err:
-        #     print(err.output)
-        #     raise
-        out = subprocess.check_call(compileArgs)
+        try:
+            out = subprocess.check_output(compileArgs, stderr=subprocess.STDOUT)
+            tPrint(3, out)
+        except subprocess.CalledProcessError as err:
+            print(err.output)
+            raise
+        # out = subprocess.check_call(compileArgs)
 
         # get hipcc version due to compatiblity reasons
         # If we aren't using hipcc what happens?

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -182,7 +182,7 @@ def getAssemblyCodeObjectFiles(kernels, kernelWriterAssembly, outputPath):
             for src, dst in (
                 zip(origCOFiles, newCOFiles)
                 if globalParameters["PrintLevel"] == 0
-                else Utils.tqdm(zip(origCOFiles, newCOFiles), msg="Copying code objects")
+                else Utils.tqdm(zip(origCOFiles, newCOFiles), desc="Copying code objects")
             ):
                 shutil.copyfile(src, dst)
             coFiles += newCOFiles
@@ -654,7 +654,7 @@ def writeKernels(
     kernelHelperObjs: List[KernelWriterBase],
     kernelWriterSource: KernelWriterSource,
     kernelWriterAssembly: KernelWriterAssembly,
-    errorTolerant: bool = False,
+    errorTolerant: bool=True,
 ):
     start = time.time()
 
@@ -700,7 +700,7 @@ def writeKernels(
         itertools.repeat(kernelWriterSource),
         itertools.repeat(kernelWriterAssembly),
     )
-    results = Common.ParallelMap(processKernelSource, kIter, "Generating kernels", verbose=0)
+    results = Common.ParallelMap(processKernelSource, kIter, "Generating kernels")
     kernels, solutions, results = filterProcessingErrors(
         kernels, solutions, results, params["PrintLevel"], errorTolerant
     )
@@ -1310,7 +1310,7 @@ def generateLogicData(
         master solution library for all architectures.
     """
     libraries = parseLibraryLogicFiles(logicFiles)
-    logicList = libraries if not printLevel else Utils.tqdm(libraries, msg="Processing logic data")
+    logicList = libraries if not printLevel else Utils.tqdm(libraries, desc="Processing logic data")
     masterLibraries = makeMasterLibraries(logicList, separate)
     if separate:
         addFallback(masterLibraries)

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -654,7 +654,7 @@ def writeKernels(
     kernelHelperObjs: List[KernelWriterBase],
     kernelWriterSource: KernelWriterSource,
     kernelWriterAssembly: KernelWriterAssembly,
-    errorTolerant: bool=True,
+    errorTolerant: bool = True,
 ):
     start = time.time()
 

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -244,7 +244,7 @@ def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile):
         archFlags = ["--offload-arch=" + arch for arch in cmdlineArchs]
 
         # needs to be fixed when Maneesh's change is made available
-        hipFlags = ["-D__HIP_HCC_COMPAT_MODE__=1"]
+        hipFlags = ["-D__HIP_HCC_COMPAT_MODE__=1", "-v"]
         hipFlags += (
             ["--genco"] if CxxCompiler == "hipcc" else ["--cuda-device-only", "-x", "hip", "-O3"]
         )

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -654,7 +654,7 @@ def writeKernels(
     kernelHelperObjs: List[KernelWriterBase],
     kernelWriterSource: KernelWriterSource,
     kernelWriterAssembly: KernelWriterAssembly,
-    errorTolerant: bool = True,
+    errorTolerant: bool = False,
 ):
     start = time.time()
 

--- a/Tensile/Utils.py
+++ b/Tensile/Utils.py
@@ -48,7 +48,7 @@ class ProgressBar:
         createTime: The timestamp when the progress bar was created.
         message: The message displayed alongside the progress bar.
     """
-    def __init__(self, maxValue: int, msg: str, width=40):
+    def __init__(self, maxValue: int, desc: str, width=40):
         self.char: str = '█'
         self.maxValue: int = maxValue
         self.width: int = width
@@ -59,7 +59,7 @@ class ProgressBar:
         self.numTicks: int = 0
         self.createTime: float = time.time()
 
-        self.message: str = "# " + msg
+        self.message: str = "# " + desc
 
     def increment(self, value=1):
         """Increments the progress bar by a given value and updates the display."""
@@ -111,8 +111,8 @@ class SpinnyThing:
         count: A counter to control the update frequency of the spinner.
         createTime: The timestamp when the spinner was created.
     """
-    def __init__(self, msg: str):
-        self.msg: str = "# " + msg
+    def __init__(self, desc: str):
+        self.message: str = "# " + desc
         self.chars: List[str] = ['|', '/', '-', '\\']
         self.index: int = 0
         self.count: int = 0
@@ -124,22 +124,22 @@ class SpinnyThing:
         if self.count % 3 != 0:
             return
 
-        sys.stdout.write('\r' + ' ' * (len(self.msg) + 10))
+        sys.stdout.write('\r' + ' ' * (len(self.message) + 10))
         sys.stdout.flush()
 
-        sys.stdout.write('\r' + self.msg + " " + self.chars[self.index])
+        sys.stdout.write('\r' + self.message + " " + self.chars[self.index])
         sys.stdout.flush()
         self.index = (self.index + 1) % len(self.chars)
 
     def finish(self):
         """Clears the spinner and displays a completion message with the elapsed time."""
-        sys.stdout.write('\r' + ' ' * (len(self.msg) + 10))
+        sys.stdout.write('\r' + ' ' * (len(self.message) + 10))
         sys.stdout.flush()
 
         stopTime = time.time()
         elapsedTime = stopTime - self.createTime
 
-        sys.stdout.write('\r' + self.msg + f'... Done in {elapsedTime:.1f} secs\n')
+        sys.stdout.write('\r' + self.message + f'... Done in {elapsedTime:.1f} secs\n')
         sys.stdout.flush()
 
 def iterate_progress(obj, *args, **kwargs):

--- a/Tensile/Utils.py
+++ b/Tensile/Utils.py
@@ -68,7 +68,7 @@ class ProgressBar:
         sys.stdout.write('\r')
         sys.stdout.write(' ' * (len(self.message) + self.maxTicks + 15) + '\r')
         stopTime = time.time()
-        sys.stdout.write(f"{self.message}... Done ({stopTime - self.createTime:.1f} secs elapsed)\n")
+        sys.stdout.write(f"{self.message}... Done in {stopTime - self.createTime:.1f} secs\n")
         sys.stdout.flush()
 
 class SpinnyThing:
@@ -99,7 +99,7 @@ class SpinnyThing:
         stopTime = time.time()
         elapsedTime = stopTime - self.createTime
         # Write the final message with elapsed time
-        sys.stdout.write('\r' + self.msg + f'... Done ({elapsedTime:.1f} secs)\n')
+        sys.stdout.write('\r' + self.msg + f'... Done in {elapsedTime:.1f} secs\n')
         sys.stdout.flush()
 
 def iterate_progress(obj, *args, **kwargs):
@@ -108,7 +108,7 @@ def iterate_progress(obj, *args, **kwargs):
         kwargs['msg'] = 'Processing unknown function'
     try:
         progress = ProgressBar(len(obj), kwargs['msg'])
-    except TypeError as e:
+    except TypeError:
         progress = SpinnyThing(kwargs['msg'])
     for o in obj:
         yield o

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ pyyaml
 msgpack
 joblib
 rich
-
+tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ pyyaml
 msgpack
 joblib
 rich
-tqdm


### PR DESCRIPTION
rocBLAS's build should be as clean as possible, with some build reporting details. This PR resolves a warning that was previously emitted in ContractionSolution.cpp and suppresses warnings that we are not in a position to resolve at the moment when verbosity is set to 0.

Collectively, these changes print the following output when building rocBLAS, as it relates to Tensile.

```
[  0%] Generating libraries with TensileCreateLibrary
[  0%] Generating /mnt/host/rocBLAS-internal/build/release/include/rocblas/internal/rocblas_device_malloc.hpp
[  0%] Built target rocblas_device_malloc
[  1%] Generating prototypes from /mnt/host/rocBLAS-internal/library/src.
[  1%] Built target rocblas_proto_templates
# Reading logic files: 32 threads, 154 tasks... Done in 3.1 secs
# Generating kernels: 32 threads... Done in 10.2 secs
# Compiling source kernels: 32 threads... Done in 1.2 secs
[  1%] Verifying files in /mnt/host/rocBLAS-internal/build/release/Tensile/library/TensileManifest.txt were generated
```