### PR TITLE
Reorder extensions for windows in which function

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -2299,7 +2299,7 @@ def which(p):
     if supportedCompiler(p) and 'CMAKE_CXX_COMPILER' in os.environ and os.path.isfile(os.environ['CMAKE_CXX_COMPILER']):
         return os.environ['CMAKE_CXX_COMPILER']
     if os.name == "nt":
-        exes = [p+x for x in ['', '.bat']]  # bat may be front end for file with no extension
+        exes = [p+x for x in ['.exe', '', '.bat']]  # bat may be front end for file with no extension
     else:
         exes = [p+x for x in ['', '.exe', '.bat']]
     system_path = os.environ['PATH'].split(os.pathsep)

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -2299,7 +2299,7 @@ def which(p):
     if supportedCompiler(p) and 'CMAKE_CXX_COMPILER' in os.environ and os.path.isfile(os.environ['CMAKE_CXX_COMPILER']):
         return os.environ['CMAKE_CXX_COMPILER']
     if os.name == "nt":
-        exes = [p+x for x in ['.bat', '', '.exe']]  # bat may be front end for file with no extension
+        exes = [p+x for x in ['', '.bat']]  # bat may be front end for file with no extension
     else:
         exes = [p+x for x in ['', '.exe', '.bat']]
     system_path = os.environ['PATH'].split(os.pathsep)


### PR DESCRIPTION
Resolving windows failure:

[11/677] Verifying files in C:/github/rocBLAS/build/release/Tensile/library/TensileManifest.txt were generated
DeveloperWarning: HardwareMonitor currently disabled for gfx941, gfx942,
gfx1100, gfx1101, gfx1102, gfx1200, gfx1201
Bareword found where operator expected at C:\hipCI\bin\hipcc.bat line 1, near "@set HIPCC"
        (Missing operator before HIPCC?)
Array found where operator expected at C:\hipCI\bin\hipcc.bat line 2, near "@perl"
        (Missing semicolon on previous line?)
Operator or semicolon missing before %HIPCC at C:\hipCI\bin\hipcc.bat line 2.
Ambiguous use of % resolved as operator % at C:\hipCI\bin\hipcc.bat line 2.
syntax error at C:\hipCI\bin\hipcc.bat line 1, near "@set HIPCC"
Execution of C:\hipCI\bin\hipcc.bat aborted due to compilation errors.
DeveloperWarning: Error: hipcc running --version Command '['perl',
'C:\\hipCI\\bin\\hipcc.bat', '--version']' returned non-zero exit status 255.

---

**Resolution**

On Windows we do something like 
```python
cmd = "perl " + which("hipcc") + " --version"
```
But `perl hipcc.bat --version` doesn't work (though the file exists), however, `perl hipcc --version` does work, and hipcc.exe isn't a thing so we skip it when calling `which(hipcc)`. Additionally, we want `which(clang++)` to return clang++ or clang++.exe when on Windows.