### PR TITLE
Don't redundantly remove duplicates

### DIFF
--- a/Tensile/BenchmarkProblems.py
+++ b/Tensile/BenchmarkProblems.py
@@ -127,7 +127,7 @@ def writeBenchmarkFiles(stepBaseDir, solutions, problemSizes, \
 
     # get unique kernels and kernel helpers
     for solution in Utils.tqdm(solutions, desc="Finding unique solutions"):
-        solutionKernels = solution.getKernels()
+        solutionKernels = [solution.getKernels()]
         for kernel in solutionKernels:
             kName = Solution.getNameFull(kernel)
             if kName not in kernelNames:

--- a/Tensile/BenchmarkProblems.py
+++ b/Tensile/BenchmarkProblems.py
@@ -127,12 +127,11 @@ def writeBenchmarkFiles(stepBaseDir, solutions, problemSizes, \
 
     # get unique kernels and kernel helpers
     for solution in Utils.tqdm(solutions, desc="Finding unique solutions"):
-        solutionKernels = [solution.getKernels()]
-        for kernel in solutionKernels:
-            kName = Solution.getNameFull(kernel)
-            if kName not in kernelNames:
-                kernels.append(kernel)
-                kernelNames.add(kName)
+        kernel = solution.getKernels()
+        kName = Solution.getNameFull(kernel)
+        if kName not in kernelNames:
+            kernels.append(kernel)
+            kernelNames.add(kName)
 
         solutionHelperKernels = solution.getHelperKernelObjects()
         for ko in solutionHelperKernels:

--- a/Tensile/SolutionLibrary.py
+++ b/Tensile/SolutionLibrary.py
@@ -507,7 +507,7 @@ class MasterSolutionLibrary:
             naming = OriginalSolution.getMinNaming(kernels)
 
         for s in list(self.solutions.values()):
-            s.name = OriginalSolution.getNameMin(s.originalSolution.getKernels()[0], naming)
+            s.name = OriginalSolution.getNameMin(s.originalSolution.getKernels(), naming)
 
     def _remapSolutionIndicesStartingFrom(self, library, solutions: dict, curIndex: int) -> tuple:
         reIndexMap = {}

--- a/Tensile/SolutionStructs.py
+++ b/Tensile/SolutionStructs.py
@@ -1774,9 +1774,7 @@ class Solution(collections.abc.Mapping):
   def getKernels(self):
     kernel = deepcopy(self)
     kernel._state.update({"Kernel": True})
-    kernels = []
-    kernels.append(kernel)
-    return kernels
+    return kernel
 
 
   ########################################
@@ -4791,7 +4789,7 @@ class Solution(collections.abc.Mapping):
   def getNameFull(state):
     requiredParameters = {}
     for key in state:
-      if key in list(validParameters.keys()):
+      if key in validParameters:
         requiredParameters[key] = True
     return Solution.getNameMin(state, requiredParameters)
 

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -1143,7 +1143,7 @@ def generateKernelObjectsFromSolutions(
         kernelHelperObjs += solutionHelperKernels
         for ko in solutionHelperKernels:
             kernelHelperNames.add(ko.getKernelName())
-            
+
     kernelHelperObjs = list(dict.fromkeys(kernelHelperObjs))
     return (kernels, kernelHelperObjs, kernelHelperNames)
 

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -1138,14 +1138,12 @@ def generateKernelObjectsFromSolutions(
     kernelHelperNames = set()
 
     for solution in solutions:
-        kernels += solution.getKernels()
+        kernels.append(solution.getKernels())
         solutionHelperKernels = solution.getHelperKernelObjects()
         kernelHelperObjs += solutionHelperKernels
         for ko in solutionHelperKernels:
             kernelHelperNames.add(ko.getKernelName())
-
-    # remove duplicates while preserving order
-    kernels = list(dict.fromkeys(kernels))
+            
     kernelHelperObjs = list(dict.fromkeys(kernelHelperObjs))
     return (kernels, kernelHelperObjs, kernelHelperNames)
 


### PR DESCRIPTION
This PR removes a few pessimizations from Tensile. In particular, there is a call to fromkeys on a kernels list to deduplicate the list, but this work is already done on the input to the function. This operation is expensive because it requires hashing a solution which requires computing the solution name and computing solution names is a bottleneck. Further, a existence operation was cleaned up from:

```
key in list(mydict.keys())
```

to 

```
key in mydict
```

which has a small but measurable impact on runtime. Lastly, the `Solution.getKernels()` function return value was changed from returning a single element list (presumably to support operator `+` for list concat) to return the kernel in favor of `list.append()`.