### PR TITLE
Update WMMA capability command for ISA 10+

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -2048,7 +2048,7 @@ def GetAsmCaps(isaVersion: IsaVersion, compilerVersion: CompilerVersion) -> Dict
     derivedAsmCaps["HasLshlOr"]             = tryAssembler(isaVersion, "v_lshl_or_b32 v47, v36, 0x2, v34")
     derivedAsmCaps["HasSMulHi"]             = tryAssembler(isaVersion, "s_mul_hi_u32 s47, s36, s34")
 
-    derivedAsmCaps["HasWMMA"]               = tryAssembler(isaVersion, "v_wmma_f32_16x16x16_f16 v[0:7], v[8:15], v[16:23], v[0:7]")
+    derivedAsmCaps["HasWMMA"]               = tryAssembler(isaVersion, "v_wmma_f32_16x16x16_f16 v[0:3], v[8:15], v[16:23], v[0:3]")
     derivedAsmCaps["HasMFMA"]               = tryAssembler(isaVersion, "v_mfma_f32_32x32x2bf16 a[0:31], v32, v33, a[0:31]") \
                                            or tryAssembler(isaVersion, "v_mfma_f32_32x32x1_2b_f32 a[0:31], v0, v1, a[0:31]")
     derivedAsmCaps["HasMFMA_constSrc"]      = tryAssembler(isaVersion, "v_mfma_f32_32x32x2bf16 a[0:31], v32, v33, 0") \
@@ -2181,6 +2181,9 @@ def tryAssembler(isaVersion, asmString, debug=False, *options):
   options = list(options)
   if globalParameters["PrintLevel"] >= 3:
     debug = True
+
+  if isaVersion[0] >= 10:
+    options += ['-mwavefrontsize64']
 
   assembler = globalParameters['AssemblerPath']
   if assembler is None:

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -2048,10 +2048,7 @@ def GetAsmCaps(isaVersion: IsaVersion, compilerVersion: CompilerVersion) -> Dict
     derivedAsmCaps["HasLshlOr"]             = tryAssembler(isaVersion, "v_lshl_or_b32 v47, v36, 0x2, v34")
     derivedAsmCaps["HasSMulHi"]             = tryAssembler(isaVersion, "s_mul_hi_u32 s47, s36, s34")
 
-    useWavefront64 = (isaVersion[0] >= 10)
-    inst = "v_wmma_f32_16x16x16_f16 v[0:3], v[8:15], v[16:23], v[0:3]" if useWavefront64 else "v_wmma_f32_16x16x16_f16 v[0:7], v[8:15], v[16:23], v[0:7]"
-    derivedAsmCaps["HasWMMA"]               = tryAssembler(isaVersion, inst)
-
+    derivedAsmCaps["HasWMMA"]               = tryAssembler(isaVersion, "v_wmma_f32_16x16x16_f16 v[0:7], v[8:15], v[16:23], v[0:7]")
     derivedAsmCaps["HasMFMA"]               = tryAssembler(isaVersion, "v_mfma_f32_32x32x2bf16 a[0:31], v32, v33, a[0:31]") \
                                            or tryAssembler(isaVersion, "v_mfma_f32_32x32x1_2b_f32 a[0:31], v0, v1, a[0:31]")
     derivedAsmCaps["HasMFMA_constSrc"]      = tryAssembler(isaVersion, "v_mfma_f32_32x32x2bf16 a[0:31], v32, v33, 0") \
@@ -2184,9 +2181,6 @@ def tryAssembler(isaVersion, asmString, debug=False, *options):
   options = list(options)
   if globalParameters["PrintLevel"] >= 3:
     debug = True
-
-  if isaVersion[0] >= 10:
-    options += ['-mwavefrontsize64']
 
   assembler = globalParameters['AssemblerPath']
   if assembler is None:

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -2048,7 +2048,10 @@ def GetAsmCaps(isaVersion: IsaVersion, compilerVersion: CompilerVersion) -> Dict
     derivedAsmCaps["HasLshlOr"]             = tryAssembler(isaVersion, "v_lshl_or_b32 v47, v36, 0x2, v34")
     derivedAsmCaps["HasSMulHi"]             = tryAssembler(isaVersion, "s_mul_hi_u32 s47, s36, s34")
 
-    derivedAsmCaps["HasWMMA"]               = tryAssembler(isaVersion, "v_wmma_f32_16x16x16_f16 v[0:7], v[8:15], v[16:23], v[0:7]")
+    useWavefront64 = (isaVersion[0] >= 10)
+    inst = "v_wmma_f32_16x16x16_f16 v[0:3], v[8:15], v[16:23], v[0:3]" if useWavefront64 else "v_wmma_f32_16x16x16_f16 v[0:7], v[8:15], v[16:23], v[0:7]"
+    derivedAsmCaps["HasWMMA"]               = tryAssembler(isaVersion, inst)
+
     derivedAsmCaps["HasMFMA"]               = tryAssembler(isaVersion, "v_mfma_f32_32x32x2bf16 a[0:31], v32, v33, a[0:31]") \
                                            or tryAssembler(isaVersion, "v_mfma_f32_32x32x1_2b_f32 a[0:31], v0, v1, a[0:31]")
     derivedAsmCaps["HasMFMA_constSrc"]      = tryAssembler(isaVersion, "v_mfma_f32_32x32x2bf16 a[0:31], v32, v33, 0") \


### PR DESCRIPTION
When using a wavefront size of 64, we should pass the following instruction to `tryAssembler`:

```
"v_wmma_f32_16x16x16_f16 v[0:3], v[8:15], v[16:23], v[0:3]"
```

when using using a wavefront size of 32 we should use:

```
"v_wmma_f32_16x16x16_f16 v[0:7], v[8:15], v[16:23], v[0:7]"
```

edit: We have opted to only support wave64 WMMA instructions for ISA 10+.

**Testing**

Compiler version: `amdclang++ --version`
```
AMD clang version 19.0.0git (ssh://gerritgit/lightning/ec/llvm-project amd-staging-npi 24284 cb5089623b3268b2628b009afa71fbf00ea5d27a)
```

Operating system images: RHEL8, Ubuntu 20, Ubuntu 22