### PR TITLE
Disable test that hangs

### DIFF
--- a/Tensile/Tests/extended/local_split_u/f8gemm_lsu_mfma.yaml
+++ b/Tensile/Tests/extended/local_split_u/f8gemm_lsu_mfma.yaml
@@ -1,5 +1,5 @@
 TestParameters:
-  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx90a, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx90a, skip-gfx940, skip-gfx941, skip-gfx942, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
 
 GlobalParameters:
   NumElementsToValidate: -1


### PR DESCRIPTION
The f8gemm_lsu_mfma test hangs is potentially causing a hang in pipelines. 