### PR TITLE
Resolve failures on SLES

### DIFF
--- a/HostLibraryTests/DecisionTree_test.cpp
+++ b/HostLibraryTests/DecisionTree_test.cpp
@@ -369,6 +369,8 @@ TEST(DecisionTree, DecisionTreeBatch)
     using SizeInRange = Predicates::Contraction::SizeInRange;
     using Range       = Predicates::Contraction::Range;
     using And         = Predicates::And<ContractionProblem>;
+    using Key         = std::array<float, 4>;
+    using DTree       = Tree<Key, std::shared_ptr<ContractionLibrary>, std::shared_ptr<ContractionSolution>>;    
     using BForest     = BasicForest<Key,
                                 ContractionProblem,
                                 std::shared_ptr<ContractionLibrary>,

--- a/HostLibraryTests/DecisionTree_test.cpp
+++ b/HostLibraryTests/DecisionTree_test.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/HostLibraryTests/DecisionTree_test.cpp
+++ b/HostLibraryTests/DecisionTree_test.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/HostLibraryTests/DecisionTree_test.cpp
+++ b/HostLibraryTests/DecisionTree_test.cpp
@@ -371,9 +371,10 @@ TEST(DecisionTree, DecisionTreeBatch)
     using And         = Predicates::And<ContractionProblem>;
     // Create a Key4 aliase specific to this test because this test uses four features which
     // requires a size four Key type; whereas previous tests only use three features.
-    using Key4        = std::array<float, 4>; 
-    using DTree4      = Tree<Key4, std::shared_ptr<ContractionLibrary>, std::shared_ptr<ContractionSolution>>;    
-    using BForest     = BasicForest<Key4,
+    using Key4 = std::array<float, 4>;
+    using DTree4
+        = Tree<Key4, std::shared_ptr<ContractionLibrary>, std::shared_ptr<ContractionSolution>>;
+    using BForest = BasicForest<Key4,
                                 ContractionProblem,
                                 std::shared_ptr<ContractionLibrary>,
                                 std::shared_ptr<ContractionSolution>>;

--- a/HostLibraryTests/DecisionTree_test.cpp
+++ b/HostLibraryTests/DecisionTree_test.cpp
@@ -369,9 +369,11 @@ TEST(DecisionTree, DecisionTreeBatch)
     using SizeInRange = Predicates::Contraction::SizeInRange;
     using Range       = Predicates::Contraction::Range;
     using And         = Predicates::And<ContractionProblem>;
-    using Key         = std::array<float, 4>;
-    using DTree       = Tree<Key, std::shared_ptr<ContractionLibrary>, std::shared_ptr<ContractionSolution>>;    
-    using BForest     = BasicForest<Key,
+    // Create a Key4 aliase specific to this test because this test uses four features which
+    // requires a size four Key type; whereas previous tests only use three features.
+    using Key4        = std::array<float, 4>; 
+    using DTree4      = Tree<Key4, std::shared_ptr<ContractionLibrary>, std::shared_ptr<ContractionSolution>>;    
+    using BForest     = BasicForest<Key4,
                                 ContractionProblem,
                                 std::shared_ptr<ContractionLibrary>,
                                 std::shared_ptr<ContractionSolution>>;
@@ -412,9 +414,9 @@ TEST(DecisionTree, DecisionTreeBatch)
     features.push_back(boundSize);
 
     // Make trees library
-    std::vector<DTree> region1trees;
+    std::vector<DTree4> region1trees;
 
-    DTree region1tree0{{
+    DTree4 region1tree0{{
         {0, 5000.f, IDX_RETURN_FALSE, IDX_RETURN_TRUE}, // YES for freeSizeA > 5000
     }};
     region1tree0.value = region1Library0;
@@ -428,9 +430,9 @@ TEST(DecisionTree, DecisionTreeBatch)
     region1dtreelib->forest = region1forest;
 
     // Make trees library
-    std::vector<DTree> region2trees;
+    std::vector<DTree4> region2trees;
 
-    DTree region2tree0{{
+    DTree4 region2tree0{{
         {0, 5000.f, IDX_RETURN_TRUE, IDX_RETURN_FALSE}, // YES for freeSizeA <= 5000
     }};
     region2tree0.value = region2Library0;

--- a/Tensile/Source/lib/source/llvm/Loading.cpp
+++ b/Tensile/Source/lib/source/llvm/Loading.cpp
@@ -44,7 +44,7 @@ namespace Tensile
 
         try
         {
-            auto inputFile = llvm::MemoryBuffer::getFile(filename);
+            auto inputFile = llvm::MemoryBuffer::getFileAsStream(filename);
 
             LibraryIOContext<MySolution> context{filename, preloaded, nullptr};
             llvm::yaml::Input            yin((*inputFile)->getMemBufferRef(), &context);

--- a/Tensile/Source/lib/source/llvm/Loading.cpp
+++ b/Tensile/Source/lib/source/llvm/Loading.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
These changes solve test failures in SLES containers when running TensileTests. 

**Fixes**

1. The decision tree test fix is a bug (out of bounds error) in the test code that isn't caught on other platforms. 
2. The change in _Loading.cpp_ was necessary to avoid another segfault when running `getFile`. The other function achieves the same outcome but does not depend on boost optional which seems to cause a segfault when initializing in the context of this code.