### PR TITLE
Call min with matching types

### DIFF
--- a/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -1871,7 +1871,7 @@ namespace Tensile
         // whichever is minimum.
         else if(pAMDGPU->skMaxCUs > 0)
         {
-            return min(cuCount, pAMDGPU->skMaxCUs);
+            return min(cuCount, static_cast<size_t>(pAMDGPU->skMaxCUs));
         }
 
         // Multiply the cuCount with a constant factor (c), and launch


### PR DESCRIPTION
**Summary:**

A build failure has been created in Tensile while fixing a compiler bug related to the `min` function in the LLVM project. The issue arises from a call to `min(unsigned long, int)` in `ContractionSolution.cpp`. The compiler now only defines multiple functions that don't require an implicit case, but none match this specific signature.

**Outcomes:**

This change modifies the problematic line to use an explicit cast when invoking `min` such that `min(unsigned long, unsigned long)` is called.

**Testing and Environment:**
- ROCm 6.3, Ubuntu 22, Python 3.10.
- Tested against rocBLAS PTS (fill in results)