### PR TITLE
Don't add fallbacks if they weren't requested

### DIFF
--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -1332,7 +1332,7 @@ def generateLogicData(
     libraries = parseLibraryLogicFiles(logicFiles)
     logicList = libraries if not printLevel else Utils.tqdm(libraries, desc="Processing logic data")
     masterLibraries = makeMasterLibraries(logicList, separate)
-    if separate:
+    if separate and "fallback" in masterLibraries:
         addFallback(masterLibraries)
     applyNaming(masterLibraries)
     for lib in masterLibraries.values():


### PR DESCRIPTION
**Summary:**

When running TensileCreateLibrary for separate archs where no logic files are present with Hip in the name, the program fails. We need to inspect the dictionary to see if fallback is a key prior to attempting to add fallback libraries.

**Outcomes:**

Fixes a regression that prevents TensileCreateLibrary from completing when fallback logic is not available.

**Testing and Environment:**

Ran pre_checkin, unit and static tests locally. Awaiting pipeline results.
