### PR TITLE
Catch accvgpr overflow

### DIFF
--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -3193,9 +3193,14 @@ class KernelWriterAssembly(KernelWriter):
         msg = "unknown"
 
       if globalParameters["PrintSolutionRejectionReason"]:
-        printWarning("%s overflowed resources.  errorCode=%d, msg=\"%s\", vgprs=%u, sgprs=%u, accvgprs=%u" \
-          % (self.kernelName, self.overflowedResources, msg, \
-          self.vgprPool.size(), self.sgprPool.size()), self.agprPool.size())
+        printWarning(
+            f"{self.kernelName} overflowed resources. errorCode={self.overflowedResources}" \
+             ", msg='{msg}', vgprs={self.vgprPool.size()}, sgprs={self.sgprPool.size()}" 
+            + f"accvgprs={self.agprPool.size()}" if kernel["EnableMatrixInstruction"] else ""
+        )
+        # printWarning("%s overflowed resources.  errorCode=%d, msg=\"%s\", vgprs=%u, sgprs=%u, accvgprs=%u" \
+        #   % (self.kernelName, self.overflowedResources, msg, \
+        #   self.vgprPool.size(), self.sgprPool.size(), self.agprPool.size()))
       kStr += "s_endpgm // overflowed resources\n"
       kStr += ".if 0\n"
 
@@ -15403,7 +15408,7 @@ class KernelWriterAssembly(KernelWriter):
       self.overflowedResources = 1
     elif self.sgprPool.size() > self.maxSgprs:
       self.overflowedResources = 2
-    elif self.agprPool.size() > self.maxAgprs:
+    elif kernel["EnableMatrixInstruction"] and self.agprPool.size() > self.maxAgprs:
       self.overflowedResources = 7
 
     if kernel["ScheduleIterAlg"] == 2 and \

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -3196,7 +3196,7 @@ class KernelWriterAssembly(KernelWriter):
         printWarning(
             f"{self.kernelName} overflowed resources. errorCode={self.overflowedResources}" \
             f", msg='{msg}', vgprs={self.vgprPool.size()}, sgprs={self.sgprPool.size()}" 
-            + f"accvgprs={self.agprPool.size()}" if kernel["EnableMatrixInstruction"] else ""
+            + f", accvgprs={self.agprPool.size()}" if kernel["EnableMatrixInstruction"] else ""
         )
       kStr += "s_endpgm // overflowed resources\n"
       kStr += ".if 0\n"

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -3192,9 +3192,9 @@ class KernelWriterAssembly(KernelWriter):
         msg = "unknown"
 
       if globalParameters["PrintSolutionRejectionReason"]:
-        printWarning("%s overflowed resources.  errorCode=%d, msg=\"%s\", vgprs=%u, sgprs=%u" \
+        printWarning("%s overflowed resources.  errorCode=%d, msg=\"%s\", vgprs=%u, sgprs=%u, accvgprs=%u" \
           % (self.kernelName, self.overflowedResources, msg, \
-          self.vgprPool.size(), self.sgprPool.size()))
+          self.vgprPool.size(), self.sgprPool.size()), self.agprPool.size())
       kStr += "s_endpgm // overflowed resources\n"
       kStr += ".if 0\n"
 

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -184,6 +184,7 @@ class KernelWriterAssembly(KernelWriter):
     self.maxVgprs = 256
     # max allowed is 112 out of 112 , 6 is used by hardware 4 SGPRs are wasted
     self.maxSgprs = 102
+    self.maxAgprs = 256
     self.maxOccupancy = 10
 
     self.endLine = "\n"
@@ -15402,7 +15403,7 @@ class KernelWriterAssembly(KernelWriter):
       self.overflowedResources = 1
     elif self.sgprPool.size() > self.maxSgprs:
       self.overflowedResources = 2
-    elif self.agprPool.size() > self.totalAgprs:
+    elif self.agprPool.size() > self.maxAgprs:
       self.overflowedResources = 7
 
     if kernel["ScheduleIterAlg"] == 2 and \

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -3195,12 +3195,9 @@ class KernelWriterAssembly(KernelWriter):
       if globalParameters["PrintSolutionRejectionReason"]:
         printWarning(
             f"{self.kernelName} overflowed resources. errorCode={self.overflowedResources}" \
-             ", msg='{msg}', vgprs={self.vgprPool.size()}, sgprs={self.sgprPool.size()}" 
+            f", msg='{msg}', vgprs={self.vgprPool.size()}, sgprs={self.sgprPool.size()}" 
             + f"accvgprs={self.agprPool.size()}" if kernel["EnableMatrixInstruction"] else ""
         )
-        # printWarning("%s overflowed resources.  errorCode=%d, msg=\"%s\", vgprs=%u, sgprs=%u, accvgprs=%u" \
-        #   % (self.kernelName, self.overflowedResources, msg, \
-        #   self.vgprPool.size(), self.sgprPool.size(), self.agprPool.size()))
       kStr += "s_endpgm // overflowed resources\n"
       kStr += ".if 0\n"
 

--- a/Tensile/KernelWriterAssembly.py
+++ b/Tensile/KernelWriterAssembly.py
@@ -3186,6 +3186,8 @@ class KernelWriterAssembly(KernelWriter):
           msg = "reading and writing LDS at same time require 2 LDS buffer"
       elif self.overflowedResources == 6:
         msg = "SIA2 better with occupancy 2"
+      elif self.overflowedResources == 7:
+        msg = "too many accvgprs"
       else:
         msg = "unknown"
 
@@ -15400,6 +15402,8 @@ class KernelWriterAssembly(KernelWriter):
       self.overflowedResources = 1
     elif self.sgprPool.size() > self.maxSgprs:
       self.overflowedResources = 2
+    elif self.agprPool.size() > self.totalAgprs:
+      self.overflowedResources = 7
 
     if kernel["ScheduleIterAlg"] == 2 and \
         self.getOccupancy(kernel["NumThreads"], self.vgprPool.size(), \


### PR DESCRIPTION
**Summary:**

Currently, the assembly kernel writer does not catch accvgpr overflows, which is causing failures in QA testing for incorrect Tensile (YAML) configurations. While we can always request the testing configs to be changed, Tensile should still gracefully reject configurations with accvpgr >= 256.

**Outcomes:**

1. Add overflow handling logic if to reject kernels with accvgprs >= 256
2. Update print statement with rejection reason.

**Testing and Environment:**

- Device: gfx942
- OS: RHEL 9
- HIP version: 6.2.41133-dd7f95766
- AMD clang version 18.0.0

Command(s):
```bash
./Tensile/bin/Tensile --cxx-compiler=hipcc ../fp16.yaml logs-fp16 | tee output-fp16.txt
./Tensile/bin/Tensile --cxx-compiler=hipcc ../fp32.yaml logs-fp16 | tee output-fp32.txt
./Tensile/bin/Tensile --cxx-compiler=hipcc ../bf16.yaml logs-fp16 | tee output-bf16.txt
```
