### PR TITLE
Suppress developer warnings

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -2525,9 +2525,10 @@ def assignGlobalParameters( config ):
       config["NumMergedFiles"] = 1
       printWarning("--num-merged-files and --no-merge-files specified, ignoring --num-merged-files")
 
+  rejectGlobalParameters = {"LogicPath", "OutputPath", "EmbedLibraryKey", "Version", "BuildClient", "ClientConfig", "WriteMasterSolutionIndex"}
   for key in config:
     value = config[key]
-    if key not in globalParameters:
+    if key not in globalParameters and key not in rejectGlobalParameters:
       printWarning("Global parameter %s = %s unrecognized." % ( key, value ), DeveloperWarning)
     globalParameters[key] = value
 

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -2527,8 +2527,10 @@ def assignGlobalParameters( config ):
 
   rejectGlobalParameters = {"LogicPath", "OutputPath", "EmbedLibraryKey", "Version", "BuildClient", "ClientConfig", "WriteMasterSolutionIndex"}
   for key in config:
+    if key in rejectGlobalParameters:
+      continue
     value = config[key]
-    if key not in globalParameters and key not in rejectGlobalParameters:
+    if key not in globalParameters:
       printWarning("Global parameter %s = %s unrecognized." % ( key, value ), DeveloperWarning)
     globalParameters[key] = value
 

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -58,7 +58,7 @@ class DeveloperWarning(Warning):
     """
 
 def showwarning(message, category, filename, lineno, file=None, line=None):
-    msg = f"{category.__name__}: {message}"
+    msg = f"> {category.__name__}: {message}"
     if TENSILE_TERM_COLORS:
         msg = f"[yellow]{msg}[/yellow]"
     print(msg)

--- a/Tensile/TensileCreateLib/ParseArguments.py
+++ b/Tensile/TensileCreateLib/ParseArguments.py
@@ -293,8 +293,8 @@ def parseArguments(input: Optional[List[str]] = None) -> Dict[str, Any]:
         os.environ["CMAKE_CXX_COMPILER"] = args.CmakeCxxCompiler
     if args.NoEnumerate:
         arguments["ROCmAgentEnumeratorPath"] = False
-    # Generated sources are preserved and go into output directory
     if args.GenerateSourcesAndExit:
+        # Generated sources are preserved and go into output directory
         arguments["WorkingPath"] = arguments["OutputPath"]
     if args.PrintLevel <= 1:
         warnings.filterwarnings("ignore", category=DeveloperWarning)

--- a/Tensile/TensileCreateLib/ParseArguments.py
+++ b/Tensile/TensileCreateLib/ParseArguments.py
@@ -293,10 +293,10 @@ def parseArguments(input: Optional[List[str]] = None) -> Dict[str, Any]:
         os.environ["CMAKE_CXX_COMPILER"] = args.CmakeCxxCompiler
     if args.NoEnumerate:
         arguments["ROCmAgentEnumeratorPath"] = False
+    # Generated sources are preserved and go into output directory
     if args.GenerateSourcesAndExit:
-        # Generated sources are preserved and go into output directory
         arguments["WorkingPath"] = arguments["OutputPath"]
-    if args.PrintLevel == 0:
+    if args.PrintLevel <= 1:
         warnings.filterwarnings("ignore", category=DeveloperWarning)
 
     for k, v in args.GlobalParameters:

--- a/Tensile/TensileCreateLib/ParseArguments.py
+++ b/Tensile/TensileCreateLib/ParseArguments.py
@@ -296,7 +296,7 @@ def parseArguments(input: Optional[List[str]] = None) -> Dict[str, Any]:
     if args.GenerateSourcesAndExit:
         # Generated sources are preserved and go into output directory
         arguments["WorkingPath"] = arguments["OutputPath"]
-    if args.PrintLevel <= 1:
+    if args.PrintLevel <= 0:
         warnings.filterwarnings("ignore", category=DeveloperWarning)
 
     for k, v in args.GlobalParameters:

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -626,7 +626,7 @@ def filterProcessingErrors(
     for kernIdx, res in (
         enumerate(results)
         if globalParameters["PrintLevel"] == 0
-        else Utils.tqdm(enumerate(results))
+        else Utils.tqdm(enumerate(results), desc="Filtering errors")
     ):
         (err, src, header, kernelName, filename) = res
         if err == -2:


### PR DESCRIPTION
**Summary:**

For most purposes, dev warnings are irrelevant and cause confusion.

**Outcomes:**

Developer warnings are only shown at PrintLevel == 2 and above, e.g., `--verbose=2`.

**Testing and Environment:**

CI only.