### PR TITLE
Support single threading

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -57,13 +57,6 @@ class DeveloperWarning(Warning):
     This warning can be safely ignored when running any Tensile applications as a user.
     """
 
-def showwarning(message, category, filename, lineno, file=None, line=None):
-    msg = f"> {category.__name__}: {message}"
-    if TENSILE_TERM_COLORS:
-        msg = f"[yellow]{msg}[/yellow]"
-    print(msg)
-
-warnings.showwarning = showwarning
 
 # print level
 # 0 - user wants no printing

--- a/Tensile/KernelWriter.py
+++ b/Tensile/KernelWriter.py
@@ -5438,7 +5438,7 @@ for codeObjectFileName in codeObjectFileNames:
     objectFileName = base + '.o'
 
     args = self.getCompileArgs(assemblyFileName, objectFileName)
-    tPrint(2, 'Assembled kernel object file: ' + ' '.join(args) + " && ")
+    tPrint(2, "Assemble command: " + " ".join(args) + " && ")
 
     # change to use  check_output to force windows cmd block util command finish
     try:

--- a/Tensile/Parallel.py
+++ b/Tensile/Parallel.py
@@ -68,7 +68,6 @@ def ParallelMap(
     message: str = "",
     enable: bool = True,
     multiArg: bool = True,
-    verbose: int = 2,
 ):
     """Executes a function over a list of objects in parallel or sequentially.
 
@@ -95,13 +94,11 @@ def ParallelMap(
     from .Common import globalParameters
 
     threadCount = CPUThreadCount(enable)
+
     message += (
-        f": {function.__name__}"
-        if verbose > 1
-        else ("") + f": {threadCount} thread(s)" + f", {len(objects)} tasks"
-            if hasattr(objects, "__len__")
-            else ""
-        )
+        f": {threadCount} thread(s)" + f", {len(objects)} tasks"
+        if hasattr(objects, "__len__")
+        else ""
     )
 
     if threadCount <= 1 or joblib is None:

--- a/Tensile/Parallel.py
+++ b/Tensile/Parallel.py
@@ -25,7 +25,6 @@
 import itertools
 import os
 from typing import Any, Callable
-
 from joblib import Parallel, delayed
 
 def CPUThreadCount(enable=True):
@@ -55,7 +54,7 @@ def pcallWithGlobalParamsSingleArg(f, arg, newGlobalParameters):
   OverwriteGlobalParameters(newGlobalParameters)
   return f(arg)
 
-def ParallelMap(function: Callable, objects: Any, message: str="", enable: bool=True, multiArg: bool=True):
+def ParallelMap(function: Callable, objects: Any, message: str="", enable: bool=False, multiArg: bool=True, verbose: int=1):
     """Executes a function over a list of objects in parallel or sequentially.
 
     This function is generally equivalent to ``list(map(function, objects))``. However, it provides
@@ -76,16 +75,18 @@ def ParallelMap(function: Callable, objects: Any, message: str="", enable: bool=
     Returns:
         A list containing the results of applying **function** to each item in **objects**.
     """
+
     from .Common import globalParameters
     from . import Utils
+
     threadCount = CPUThreadCount(enable)
+    message += f": {function.__name__}" if verbose > 1 else "" + f": {threadCount} thread(s)" + f", {len(objects)} tasks" if hasattr(objects, "__len__") else ""
     
     if threadCount <= 1:
-      return list(map(lambda objs: function(*objs), Utils.tqdm(objects, desc=message)))
-        
-    inputs = list(zip(objects, itertools.repeat(globalParameters)))
-    message += f": {threadCount} threads, {len(inputs)} tasks"
+        f = lambda x: function(*x) if multiArg else function(x)
+        return [f(x) for x in Utils.tqdm(objects, desc=message)]
 
+    inputs = list(zip(objects, itertools.repeat(globalParameters)))
     pargs = Utils.tqdm(inputs, desc=message)
     pcall = pcallWithGlobalParamsMultiArg if multiArg else pcallWithGlobalParamsSingleArg
 

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -288,10 +288,9 @@ def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile, removeTempora
                 + [kernelFile, "-c", "-o", os.path.join(buildPath, objectFilename)]
             )
 
-        tPrint(2, "hipcc:" + " ".join(compileArgs))
+        tPrint(2, f"Build object file command: {compileArgs}")
         # change to use  check_output to force windows cmd block util command finish
         try:
-            print("Build object file command: ", compileArgs)
             out = subprocess.check_output(compileArgs, stderr=subprocess.STDOUT)
             tPrint(3, out)
         except subprocess.CalledProcessError as err:

--- a/Tensile/Utilities/ConditionalImports.py
+++ b/Tensile/Utilities/ConditionalImports.py
@@ -1,5 +1,14 @@
-TENSILE_TERM_COLORS: bool = False
+import warnings
 
+def showwarning(message, category, filename, lineno, file=None, line=None):
+    msg = f"> {category.__name__}: {message}"
+    if TENSILE_TERM_COLORS:
+        msg = f"[yellow]{msg}[/yellow]"
+    print(msg)
+
+warnings.showwarning = showwarning
+
+TENSILE_TERM_COLORS: bool = False
 try:
     from rich import print as print
     TENSILE_TERM_COLORS = True
@@ -17,7 +26,9 @@ try:
 except ImportError:
     from yaml import SafeDumper as yamlDumper
 
+
 try:
     import joblib
 except:
+    warnings.warn("Missing dependency 'joblib', program will run without parallelism")
     joblib = None

--- a/Tensile/Utilities/ConditionalImports.py
+++ b/Tensile/Utilities/ConditionalImports.py
@@ -1,10 +1,10 @@
 TENSILE_TERM_COLORS: bool = False
+
 try:
     from rich import print as print
     TENSILE_TERM_COLORS = True
 except ImportError:
     print = print
-
 
 
 try:
@@ -16,3 +16,8 @@ try:
     from yaml import CSafeDumper as yamlDumper 
 except ImportError:
     from yaml import SafeDumper as yamlDumper
+
+try:
+    import joblib
+except:
+    joblib = None

--- a/tox.ini
+++ b/tox.ini
@@ -61,6 +61,7 @@ commands =
     black \
       --line-length=100 \
       {toxinidir}/docs/ \
+      {toxinidir}/Tensile/Parallel.py \
       {toxinidir}/Tensile/TensileCreateLibrary.py \
       {toxinidir}/Tensile/TensileCreateLib/ \
       {toxinidir}/Tensile/Tests/unit/test_TensileCreateLibrary.py \

--- a/tox.ini
+++ b/tox.ini
@@ -81,6 +81,7 @@ commands =
     isort \
       --profile=black \
       {toxinidir}/docs/ \
+      {toxinidir}/Tensile/Parallel.py \
       {toxinidir}/Tensile/TensileCreateLibrary.py \
       {toxinidir}/Tensile/TensileCreateLib/ \
       {toxinidir}/Tensile/Tests/unit/test_TensileCreateLibrary.py \


### PR DESCRIPTION
**Summary:**

To improve the overall performance of Tensile, it is important to able to run in single-threaded mode. This enables better visibility into the profiling outputs because the most compute intensive functions are hidden behind joblib's pipelining primitives.

**Outcomes:**

Single-threaded operations are now supported.

**Notable changes:**

Improved test coverage on core functions in TensileCreateLibrary in addition to printing updates.

**Testing and Environment:**

- Standard framework testing process.
- Tested after running `pip3 uninstall joblib` and confirmed that the appropriate warning is emitted.