### PR TITLE
Linearize asm register search

### DIFF
--- a/Tensile/AsmRegisterPool.py
+++ b/Tensile/AsmRegisterPool.py
@@ -219,11 +219,7 @@ class RegisterPool:
         left += alignment
         right = left
 
-    if preventOverflow:
-      return None
-    else:
-      loc = self.startOfLastAvailableBlock()
-      return roundUpToNearestMultiple(loc, alignment)
+    return None if preventOverflow else left
 
 
   def checkOutAt(self, start, size, tag, preventOverflow, wantedStatus = Status.Available):

--- a/Tensile/Tests/unit/test_AsmRegisterPool.py
+++ b/Tensile/Tests/unit/test_AsmRegisterPool.py
@@ -142,11 +142,12 @@ def test_findFreeRange_noOverflowPastPoolLength():
     assert out_new == out_old
     assert out_new == 0
 
+
 def test_findFreeRange_noOverflowPastPoolLength2():
     poolSize = 12
     vgprPool = RegisterPool(poolSize, "v", defaultPreventOverflow=False, printRP=0)
 
-    vgprPool.add(0, poolSize-2, "tag")
+    vgprPool.add(0, poolSize - 2, "tag")
 
     print(vgprPool.pool)
     #   A       A       A

--- a/Tensile/Tests/unit/test_AsmRegisterPool.py
+++ b/Tensile/Tests/unit/test_AsmRegisterPool.py
@@ -1,0 +1,181 @@
+from Tensile.AsmRegisterPool import RegisterPool
+from Tensile.Utils import roundUpToNearestMultiple
+
+S = RegisterPool.Status
+
+
+def test_RegisterPool_add0():
+    poolSize = 12
+
+    vgprPool = RegisterPool(poolSize, "v", defaultPreventOverflow=False, printRP=0)
+    for reg in vgprPool.pool:
+        assert reg.status == S.Unavailable
+        assert reg.tag == "init"
+
+    vgprPool.add(0, poolSize, "tag")
+    assert len(vgprPool.pool) == poolSize
+    for reg in vgprPool.pool:
+        assert reg.status == S.Available
+        assert reg.tag == "tag"
+
+
+def test_RegisterPool_add1():
+    poolSize = 12
+    start = 8
+    vgprPool = RegisterPool(poolSize, "v", defaultPreventOverflow=False, printRP=0)
+
+    vgprPool.add(start, poolSize, "tag")
+    assert len(vgprPool.pool) == poolSize + start
+    for i, reg in enumerate(vgprPool.pool):
+        if i < start:
+            assert reg.status == S.Unavailable
+            assert reg.tag == "init"
+        else:
+            assert reg.status == S.Available
+            assert reg.tag == "tag"
+
+
+def test_findFreeRange_vgprEndToEnd1_AllAvailable():
+    poolSize = 12
+    vgprPool = RegisterPool(poolSize, "v", defaultPreventOverflow=False, printRP=0)
+
+    vgprPool.add(0, poolSize, "tag")
+    out_new = vgprPool.findFreeRange(4, 8)
+    out_old = findFreeRange_oldLogic(vgprPool, 4, 8)
+
+    assert out_new == out_old == 0
+
+
+def test_findFreeRange_noOverflowButAvailable():
+    poolSize = 12
+    vgprPool = RegisterPool(poolSize, "v", defaultPreventOverflow=True, printRP=0)
+    vgprPool.add(6, poolSize, "tag")
+
+    # Starting at index 3, find 4 free registers and return the starting index
+    out_new = vgprPool.findFreeRange(3, 4)
+    out_old = findFreeRange_oldLogic(vgprPool, 3, 4)
+
+    assert out_new == out_old == 8
+
+
+def test_findFreeRange_variableOveflowNotAvailable():
+    poolSize = 12
+    vgprPool = RegisterPool(poolSize, "v", defaultPreventOverflow=False, printRP=0)
+
+    vgprPool.add(0, 3, "tag")
+    vgprPool.add(10, 2, "tag")
+
+    #   A       A       A
+    # [ . . . | | | | | | | . . ]
+    #   0                     11
+    out_new = vgprPool.findFreeRange(4, 4, preventOverflow=True)
+    out_old = findFreeRange_oldLogic(vgprPool, 4, 4, preventOverflow=True)
+
+    # We expect to hit the preventOverflow here
+    assert out_new == out_old == None
+
+    out_new = vgprPool.findFreeRange(4, 4)
+    out_old = findFreeRange_oldLogic(vgprPool, 4, 4)
+
+    # We expect to get values from the call to `startOfLastAvailableBlock`
+    assert out_new == out_old == 12
+
+
+def test_findFreeRange_noOverflowNotAvailable():
+    poolSize = 12
+    vgprPool = RegisterPool(poolSize, "v", defaultPreventOverflow=True, printRP=0)
+
+    vgprPool.add(7, 5, "tag")
+
+    #   A       A       A
+    # [ | | | | | | | . . . . . ]
+    #   0                     11
+    out_new = vgprPool.findFreeRange(5, 4)
+    out_old = findFreeRange_oldLogic(vgprPool, 5, 4)
+
+    assert out_new == out_old == None
+
+
+def test_findFreeRange_noOverflowButPastLastSlot():
+    poolSize = 12
+    vgprPool = RegisterPool(poolSize, "v", defaultPreventOverflow=False, printRP=0)
+
+    vgprPool.add(7, 5, "tag")
+
+    #   A       A       A
+    # [ | | | | | | | . . . . . ]
+    #   0                     11
+    out_new = vgprPool.findFreeRange(5, 4)
+    out_old = findFreeRange_oldLogic(vgprPool, 5, 4)
+
+    assert out_new == out_old
+    assert out_new == 8
+
+
+def test_findFreeRange_overflowPastPoolLength():
+    poolSize = 12
+    vgprPool = RegisterPool(poolSize, "v", defaultPreventOverflow=True, printRP=0)
+
+    vgprPool.add(0, poolSize, "tag")
+
+    #   A       A       A
+    # [ . . . . . . . . . . . . ]
+    #   0                     11
+    out_new = vgprPool.findFreeRange(16, 4)
+    out_old = findFreeRange_oldLogic(vgprPool, 16, 4)
+
+    assert out_new == out_old == None
+
+
+def test_findFreeRange_noOverflowPastPoolLength():
+    poolSize = 12
+    vgprPool = RegisterPool(poolSize, "v", defaultPreventOverflow=False, printRP=0)
+
+    vgprPool.add(0, poolSize, "tag")
+
+    #   A       A       A
+    # [ . . . . . . . . . . . . ]
+    #   0                     11
+    out_new = vgprPool.findFreeRange(16, 4)
+    out_old = findFreeRange_oldLogic(vgprPool, 16, 4)
+
+    assert out_new == out_old
+    assert out_new == 0
+
+def test_findFreeRange_noOverflowPastPoolLength2():
+    poolSize = 12
+    vgprPool = RegisterPool(poolSize, "v", defaultPreventOverflow=False, printRP=0)
+
+    vgprPool.add(0, poolSize-2, "tag")
+
+    print(vgprPool.pool)
+    #   A       A       A
+    # [ | | | | | | | | | | . . ]
+    #   0                     11
+    out_new = vgprPool.findFreeRange(16, 8)
+    out_old = findFreeRange_oldLogic(vgprPool, 16, 8)
+
+    assert out_new == out_old
+    assert out_new == 16
+
+
+# ----------------
+# Helper functions
+# ----------------
+def findFreeRange_oldLogic(
+    regPool, size, alignment, preventOverflow=-1, wantedStatus=RegisterPool.Status.Available
+):
+    if preventOverflow == -1:
+        preventOverflow = regPool.defaultPreventOverflow
+
+    for i in range(len(regPool.pool) + 1):
+        if i % alignment != 0:
+            continue
+        if regPool.isRangeAvailable(i, size, preventOverflow, wantedStatus):
+            return i
+
+    if preventOverflow:
+        return None
+    else:
+        loc = regPool.startOfLastAvailableBlock()
+        return roundUpToNearestMultiple(loc, alignment)

--- a/docs/src/api-reference/AsmRegistryPool.rst
+++ b/docs/src/api-reference/AsmRegistryPool.rst
@@ -1,0 +1,8 @@
+
+.. _asmregistrypool-api-reference:
+
+===============
+AsmRegisterPool
+===============
+
+.. autofunction:: Tensile.AsmRegsiterPool::findFreeRange

--- a/tox.ini
+++ b/tox.ini
@@ -65,6 +65,7 @@ commands =
       {toxinidir}/Tensile/TensileCreateLib/ \
       {toxinidir}/Tensile/Tests/unit/test_TensileCreateLibrary.py \
       {toxinidir}/Tensile/Tests/unit/test_KernelFileContext.py \
+      {toxinidir}/Tensile/Tests/unit/test_AsmRegisterPool.py \
       {posargs}
 
 [testenv:docs]
@@ -85,6 +86,7 @@ commands =
       {toxinidir}/Tensile/TensileCreateLib/ \
       {toxinidir}/Tensile/Tests/unit/test_TensileCreateLibrary.py \
       {toxinidir}/Tensile/Tests/unit/test_KernelFileContext.py \
+      {toxinidir}/Tensile/Tests/unit/test_AsmRegisterPool.py \
       {posargs}
 
 [flake8]


### PR DESCRIPTION
**Summary:**

Profiling revealed an $O(n^2)$ implementation that can be converted into a linear $O(n)$ implementation in `AsmRegisterpool::findFreeRange`, which currently consumes 17% of the runtime of TensileCreateLibrary (under the execution conditions below). This PR updates this function to use a two-pointer algorithm that linearizes the time complexity while also avoiding eager evaluation of register availability.

**Outcomes:**

Runtime reduction when benchmarked against the current implementation is:
```
Before change: 32 jobs, gfx90a:
    7744.10s user 641.74s system 1993% cpu 7:00.56 total <--- before
After change: 32 jobs, gfx90a:
    6546.97s user 648.71s system 1908% cpu 6:17.01 total <--- after
```
Which cuts 43.55 seconds (10.4%) off the wall time of the following invocation:
```
time Tensile/bin/TensileCreateLibrary \
              ../rocBLAS/library/src/blas3/Tensile/Logic/asm_full \
              _build_tcl \
              HIP \
              --merge-files \
              --separate-architecture \
              --lazy-library-loading \
              --no-short-file-names \
              --code-object-version=default \
              --cxx-compiler=amdclang++ \
              --jobs=32 \
              --library-format=msgpack \
              --architecture='gfx90a' \
              --verbose=1 | tee results-jobs-$(date -Iseconds).log
```

**Notable changes:**

The internal call to `isRangeAvailable` has been removed from `findFreeRange`, however it is still used elsewhere in the codebase.

**Testing and Environment:**

Standard Tensile testing; Ubuntu 22.01, ROCm 6.3
