### PR TITLE
Add logic to keep build_tmp when running Tensile

### DIFF
--- a/Tensile/BenchmarkProblems.py
+++ b/Tensile/BenchmarkProblems.py
@@ -142,15 +142,18 @@ def writeBenchmarkFiles(stepBaseDir, solutions, problemSizes, \
 
     kernelSerialNaming = Solution.getSerialNaming(kernels)
     kernelMinNaming = Solution.getMinNaming(kernels)
-    kernelWriterSource = KernelWriterSource(kernelMinNaming, kernelSerialNaming)
-    kernelWriterAssembly = KernelWriterAssembly(kernelMinNaming, kernelSerialNaming)
+    kernelWriterSource = KernelWriterSource(kernelMinNaming, kernelSerialNaming, \
+                                            not globalParameters["KeepBuildTmp"])
+    kernelWriterAssembly = KernelWriterAssembly(kernelMinNaming, kernelSerialNaming, \
+                                                not globalParameters["KeepBuildTmp"])
 
     # write solution, kernels and CMake
     problemType = solutions[0]["ProblemType"]
     codeObjectFiles, kernels, solutions = writeKernels( \
             globalParameters["WorkingPath"], globalParameters["CxxCompiler"], \
             globalParameters, solutions, kernels, kernelHelperOjbs, \
-            kernelWriterSource, kernelWriterAssembly, errorTolerant=True )
+            kernelWriterSource, kernelWriterAssembly, errorTolerant=True, \
+            removeTemporaries = not globalParameters["KeepBuildTmp"])
     # ^ this is where solutions is mutated
     newLibraryDir = ensurePath(os.path.join(globalParameters["WorkingPath"], 'library'))
     newLibraryFile = os.path.join(newLibraryDir, "TensileLibrary")

--- a/Tensile/BenchmarkProblems.py
+++ b/Tensile/BenchmarkProblems.py
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# Copyright (C) 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -2390,6 +2390,9 @@ def assignGlobalParameters( config ):
     else:
       tPrint(3, " %24s: %8s (unspecified)" % (key, defaultValue))
 
+  if "KeepBuildTmp" in config:
+    globalParameters["KeepBuildTmp"] = config["KeepBuildTmp"]
+
   globalParameters["ROCmPath"] = "/opt/rocm"
   if "ROCM_PATH" in os.environ:
     globalParameters["ROCmPath"] = os.environ.get("ROCM_PATH")

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -2391,7 +2391,8 @@ def assignGlobalParameters( config ):
       tPrint(3, " %24s: %8s (unspecified)" % (key, defaultValue))
 
   if "KeepBuildTmp" in config:
-    globalParameters["KeepBuildTmp"] = config["KeepBuildTmp"]
+    globalParameters["KeepBuildTmp"] = config["KeepBuildTmp"] 
+
 
   globalParameters["ROCmPath"] = "/opt/rocm"
   if "ROCM_PATH" in os.environ:

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -250,6 +250,7 @@ globalParameters["SupportedISA"] = [(8,0,3),
                                     (11,5,1),
                                     (12,0,0), (12,0,1)] # assembly kernels writer supports these architectures
 
+globalParameters["KeepBuildTmp"] = True                           # remove build artifacts during the build process and build_tmp after build completes
 globalParameters["CleanupBuildFiles"] = False                     # cleanup build files (e.g. kernel assembly) once no longer needed
 globalParameters["GenerateManifestAndExit"] = False               # Output manifest file with list of expected library objects and exit
 globalParameters["VerifyManifest"] = False                        # Verify manifest file against generated library files and exit.
@@ -2392,7 +2393,6 @@ def assignGlobalParameters( config ):
 
   if "KeepBuildTmp" in config:
     globalParameters["KeepBuildTmp"] = config["KeepBuildTmp"] 
-
 
   globalParameters["ROCmPath"] = "/opt/rocm"
   if "ROCM_PATH" in os.environ:

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -250,8 +250,7 @@ globalParameters["SupportedISA"] = [(8,0,3),
                                     (11,5,1),
                                     (12,0,0), (12,0,1)] # assembly kernels writer supports these architectures
 
-globalParameters["KeepBuildTmp"] = True                           # remove build artifacts during the build process and build_tmp after build completes
-globalParameters["CleanupBuildFiles"] = False                     # cleanup build files (e.g. kernel assembly) once no longer needed
+globalParameters["KeepBuildTmp"] = True                           # Do not remove build artifacts during the build process or build_tmp after build completes
 globalParameters["GenerateManifestAndExit"] = False               # Output manifest file with list of expected library objects and exit
 globalParameters["VerifyManifest"] = False                        # Verify manifest file against generated library files and exit.
 globalParameters["ClientBuildPath"] = "0_Build"                   # subdirectory for host code build directory

--- a/Tensile/Tensile.py
+++ b/Tensile/Tensile.py
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/Tensile/Tensile.py
+++ b/Tensile/Tensile.py
@@ -132,6 +132,7 @@ def addCommonArguments(argParser):
 
     argParser.add_argument("--global-parameters", nargs="+", type=splitExtraParameters, default=[])
 
+
 def argUpdatedGlobalParameters(args):
     """
     Returns a dictionary with `globalParameters` keys that should be updated based on `args`.

--- a/Tensile/Tensile.py
+++ b/Tensile/Tensile.py
@@ -285,6 +285,8 @@ def Tensile(userArgs):
 
     globalParameters["OutputPath"] = ensurePath(os.path.abspath(args.output_path))
     globalParameters["WorkingPath"] = globalParameters["OutputPath"]
+    if "KeepBuildTmp" not in globalParameters:
+        globalParameters["KeepBuildTmp"] = args.KeepBuildTmp
 
     overrideParameters = argUpdatedGlobalParameters(args)
 

--- a/Tensile/Tensile.py
+++ b/Tensile/Tensile.py
@@ -29,6 +29,8 @@ if __name__ == "__main__":
 import os
 import sys
 import argparse
+import shutil
+
 from .Common import globalParameters, tPrint, printExit, ensurePath, \
     assignGlobalParameters, restoreDefaultGlobalParameters, HR, gfxArch
 from . import BenchmarkProblems
@@ -214,7 +216,6 @@ def Tensile(userArgs):
 
     addCommonArguments(argParser)
     args = argParser.parse_args(userArgs)
-
     configPaths = args.config_file
     altFormat = args.AlternateFormat
     useCache = not args.NoCache
@@ -296,6 +297,12 @@ def Tensile(userArgs):
     ClientExecutable.getClientExecutable(clientPath)
     executeStepsInConfig(config)
 
+    if not globalParameters["KeepBuildTmp"]:
+        for root, subdirs, files in os.walk(globalParameters["OutputPath"]):
+            for d in subdirs:
+                if d == "build_tmp":
+                    shutil.rmtree(os.path.join(root, d))
+                    break
 
 def TensileConfigPath(*args):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), "Configs", *args)

--- a/Tensile/Tensile.py
+++ b/Tensile/Tensile.py
@@ -131,6 +131,8 @@ def addCommonArguments(argParser):
     argParser.add_argument("--prebuilt-client", default=None)
 
     argParser.add_argument("--global-parameters", nargs="+", type=splitExtraParameters, default=[])
+    argParser.add_argument("--keep-build-tmp", dest="KeepBuildTmp", action="store_true",
+            help="Do not remove the temporary build directory")
 
 
 def argUpdatedGlobalParameters(args):

--- a/Tensile/Tensile.py
+++ b/Tensile/Tensile.py
@@ -131,9 +131,6 @@ def addCommonArguments(argParser):
     argParser.add_argument("--prebuilt-client", default=None)
 
     argParser.add_argument("--global-parameters", nargs="+", type=splitExtraParameters, default=[])
-    argParser.add_argument("--keep-build-tmp", dest="KeepBuildTmp", action="store_true",
-            help="Do not remove the temporary build directory")
-
 
 def argUpdatedGlobalParameters(args):
     """
@@ -285,8 +282,6 @@ def Tensile(userArgs):
 
     globalParameters["OutputPath"] = ensurePath(os.path.abspath(args.output_path))
     globalParameters["WorkingPath"] = globalParameters["OutputPath"]
-    if "KeepBuildTmp" not in globalParameters:
-        globalParameters["KeepBuildTmp"] = args.KeepBuildTmp
 
     overrideParameters = argUpdatedGlobalParameters(args)
 

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -839,12 +839,6 @@ def writeKernels(
     tPrint(1, "# Kernel Building elapsed time = %.1f secs" % (stop - start))
 
     Common.popWorkingPath()  # outputPath.upper()
-
-    if globalParameters["CleanupBuildFiles"]:
-        buildTmp = Path(outputPath).parent / "build_tmp"
-        if buildTmp.exists() and buildTmp.is_dir():
-            shutil.rmtree(buildTmp)
-
     Common.popWorkingPath()  # build_tmp
 
     return codeObjectFiles, kernels, solutions


### PR DESCRIPTION
**Summary:**

Changes were added to TensileCreateLibrary to remove (or not) the `build_tmp` directory. However, the same changes were overlooked in Tensile. This PR adds the logic necessary to remove (default) or keep `build_tmp` via the `--keep-build-tmp` option.

**Outcomes:**

Temporary source files and build artifacts are available for inspection after running Tensile command.

**Notable changes:**

Adds `--keep-build-tmp` option to Tensile application.

**Testing and Environment:**

Local testing ran using a config file provided by @nakajee. After reviewing tensile ouput directory, temporary build files are removed (or not) depending on whether option is set.