### PR TITLE
External CI Enablement

### DIFF
--- a/.azuredevops/rocm-ci.yml
+++ b/.azuredevops/rocm-ci.yml
@@ -1,0 +1,44 @@
+resources:
+  repositories:
+  - repository: pipelines_repo
+    type: github
+    endpoint: ROCm
+    name: ROCm/ROCm
+
+variables:
+- group: common
+- template: /.azuredevops/variables-global.yml@pipelines_repo
+
+trigger:
+  batch: true
+  branches:
+    include:
+    - develop
+    - mainline
+  paths:
+    exclude:
+    - .github
+    - .jenkins
+    - docs
+    - tuning_docs
+    - '*.md'
+    - '.*.y*ml'
+
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - develop
+    - mainline
+  paths:
+    exclude:
+    - .github
+    - .jenkins
+    - docs
+    - tuning_docs
+    - '*.md'
+    - '.*.y*ml'
+  drafts: false
+
+jobs:
+  - template: ${{ variables.CI_COMPONENT_PATH }}/Tensile.yml@pipelines_repo

--- a/docs/src/how-to/programmers-guide.rst
+++ b/docs/src/how-to/programmers-guide.rst
@@ -187,7 +187,7 @@ To enable profiling, use the ``@profile`` decorator, which must be imported from
 External CI
 ============
 
-`Azure Pipelines <https://dev.azure.com/ROCm-CI/ROCm-CI/_build?definitionId=256>` are run for every pull request and commit targeting the develop and mainline branches.
+`Azure Pipelines <https://dev.azure.com/ROCm-CI/ROCm-CI/_build?definitionId=256>`_ are run for every pull request and commit targeting the develop and mainline branches.
 The pipeline packages up the wheel file and runs pre_checkin tests on a gfx942 system.
 `Click <https://dev.azure.com/ROCm-CI/ROCm-CI/_build?definitionId=256>` on the job corresponding to the pull request or commit to view execution logs.
 

--- a/docs/src/how-to/programmers-guide.rst
+++ b/docs/src/how-to/programmers-guide.rst
@@ -189,7 +189,7 @@ External CI
 
 `Azure Pipelines <https://dev.azure.com/ROCm-CI/ROCm-CI/_build?definitionId=256>`_ are run for every pull request and commit targeting the develop and mainline branches.
 The pipeline packages up the wheel file and runs pre_checkin tests on a gfx942 system.
-`Click <https://dev.azure.com/ROCm-CI/ROCm-CI/_build?definitionId=256>` on the job corresponding to the pull request or commit to view execution logs.
+`Click <https://dev.azure.com/ROCm-CI/ROCm-CI/_build?definitionId=256>`_ on the job corresponding to the pull request or commit to view execution logs.
 
 ========================
 Building documentation

--- a/docs/src/how-to/programmers-guide.rst
+++ b/docs/src/how-to/programmers-guide.rst
@@ -183,6 +183,14 @@ To enable profiling, use the ``@profile`` decorator, which must be imported from
 .. note::
    Nested profiling is NOT supported due to the existing limitation with the profiling decorator. This implies that if `func1` calls `func2` in a loop, and both are marked for profiling, the resulting ``.prof`` file for `func1` will display incorrect results.
 
+============
+External CI
+============
+
+`Azure Pipelines <https://dev.azure.com/ROCm-CI/ROCm-CI/_build?definitionId=256>` are run for every pull request and commit targeting the develop and mainline branches.
+The pipeline packages up the wheel file and runs pre_checkin tests on a gfx942 system.
+`Click <https://dev.azure.com/ROCm-CI/ROCm-CI/_build?definitionId=256>` on the job corresponding to the pull request or commit to view execution logs.
+
 ========================
 Building documentation
 ========================


### PR DESCRIPTION
Add triggers for develop and mainline branches for Tensile repo.

[Successful build and test pipeline](https://dev.azure.com/ROCm-CI/ROCm-CI/_build/results?buildId=9976&view=results)
