### PR TITLE
Use hipcc.bat as a compiler on windows, instead of the perl script

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -2483,7 +2483,7 @@ def assignGlobalParameters( config, capabilitiesCache: Optional[dict] = None ):
   # The following try except block computes the hipcc version
   try:
     if os.name == "nt":
-      compileArgs = ['perl'] + [which('hipcc')] + ['--version']
+      compileArgs = [which('hipcc.bat')] + ['--version']
       output = subprocess.run(compileArgs, check=True, stdout=subprocess.PIPE).stdout.decode()
     else:
       compiler = "hipcc"


### PR DESCRIPTION
**Summary:**

Invoke "hipcc.bat" script instead of "perl hipcc". Invoking "perl hipcc" is not ideal, because there is no guarantee that hipcc is actually a perl script.

**Outcomes:**

What components of the project does it affect?* At this point this is NFC - hipcc.bat script calls perl script.

**Notable changes:**

Not really.

**Testing and Environment:**

*What environment are you targeting (OS, ROCm version, Python versions, etc.)?* Windows

*What testing did you do to ensure this change will integrate successfully?* Hopefully you have windows PSDB :)
