### PR TITLE
Fix stream-k dynamic grid model

### DIFF
--- a/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -103,8 +103,8 @@ namespace Tensile
                                      size_t m,
                                      size_t n,
                                      size_t k,
-                                     int    grid_start = 1,
-                                     int    grid_end   = 304)
+                                     int    grid_start,
+                                     int    grid_end)
         {
             static const bool debug = Debug::Instance().printStreamKGridInfo();
 
@@ -1864,6 +1864,7 @@ namespace Tensile
                                                      x,
                                                      y,
                                                      z,
+                                                     1,
                                                      cuCount);
         }
 


### PR DESCRIPTION
There's a typo where `grid_start` is being set to `cuCount`, which should be `grid_end`. I have also removed the defaults to avoid this from happening, as `cuCount` differs from architecture to architecture and even within different compute modes.