### PR TITLE
Disable asm-cache for tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,8 +29,8 @@ commands =
 
 [testenv:ci]
 commands =
-    python3 ./Tensile/bin/Tensile --asm-cache {toxinidir}/asm-cache.yaml {toxinidir}/Tensile/Configs/build_client.yaml {envdir}/client
-    py.test {toxinidir}/Tensile/Tests {[vars]options} --asm-cache {toxinidir}/asm-cache.yaml {posargs:-m pre_checkin}
+    python3 ./Tensile/bin/Tensile {toxinidir}/Tensile/Configs/build_client.yaml {envdir}/client
+    py.test {toxinidir}/Tensile/Tests {[vars]options} {posargs:-m pre_checkin}
 
 [testenv:unittest]
 deps =


### PR DESCRIPTION
Can't resolve extended test failures so disabling asm-cache during testing