### PR TITLE
Code object compression via bundling

### DIFF
--- a/Tensile/BenchmarkProblems.py
+++ b/Tensile/BenchmarkProblems.py
@@ -150,7 +150,7 @@ def writeBenchmarkFiles(stepBaseDir, solutions, problemSizes, \
     # write solution, kernels and CMake
     problemType = solutions[0]["ProblemType"]
     codeObjectFiles, kernels, solutions = writeKernels( \
-            globalParameters["WorkingPath"], globalParameters["CxxCompiler"], \
+            globalParameters["WorkingPath"], globalParameters["CxxCompiler"], globalParameters["ClangOffloadBundlerPath"], \
             globalParameters, solutions, kernels, kernelHelperOjbs, \
             kernelWriterSource, kernelWriterAssembly, errorTolerant=True, \
             removeTemporaries = not globalParameters["KeepBuildTmp"])

--- a/Tensile/BuildCommands/AssemblyCommands.py
+++ b/Tensile/BuildCommands/AssemblyCommands.py
@@ -1,0 +1,132 @@
+import collections
+import math
+import os
+import shutil
+import subprocess
+
+from pathlib import Path
+from typing import List, Union
+
+from .. import Utils
+from ..Common import globalParameters, tPrint, ensurePath, printWarning, gfxName
+from ..KernelWriterAssembly import KernelWriterAssembly
+from ..SolutionStructs import Solution
+from .SharedCommands import compressCodeObject
+
+
+def _linkIntoCodeObject(
+    objFiles: List[str], coPathDest: Union[Path, str], kernelWriterAssembly: KernelWriterAssembly
+):
+    """Links object files into a code object file.
+
+    Args:
+        objectFiles: A list of object files to be linked.
+        coPathDest: The destination path for the code object file.
+        kernelWriterAssembly: An instance of KernelWriterAssembly to get link arguments.
+
+    Raises:
+        RuntimeError: If linker invocation fails.
+    """
+    args = []
+    if os.name == "nt":
+        # On Windows, the objectFiles list command line (including spaces)
+        # exceeds the limit of 8191 characters, so using response file
+
+        responseFile = os.path.join("/tmp", "clangArgs.txt")
+        with open(responseFile, "wt") as file:
+            file.write(" ".join(objFiles))
+            file.flush()
+
+        args = kernelWriterAssembly.getLinkCodeObjectArgs(["@clangArgs.txt"], str(coPathDest))
+    else:
+        args = kernelWriterAssembly.getLinkCodeObjectArgs(objFiles, str(coPathDest))
+
+    tPrint(2, "Linking objects into co files: " + " ".join(args))
+    try:
+        out = subprocess.check_output(args, stderr=subprocess.STDOUT)
+        tPrint(2, f"Output: {out}")
+    except subprocess.CalledProcessError as err:
+        raise RuntimeError(
+            f"Error linking object files in to code object: {err.output}\nFailed command: {' '.join(args)}"
+        )
+
+
+def buildAssemblyCodeObjectFiles(
+    bundler: str,
+    kernels: List[Solution],
+    writer: KernelWriterAssembly,
+    outputPath: Union[Path, str],
+    removeTemporaries: bool,
+):
+
+    countAsmKernels = lambda kernels: sum(k["KernelLanguage"] == "Assembly" for k in kernels)
+
+    extObj = ".o"
+    extCo = ".co"
+    extCoRaw = ".co.raw"
+
+    destDir = Path(ensurePath(os.path.join(outputPath, "library")))
+    asmDir = Path(writer.getAssemblyDirectory())
+
+    assemblyKernels = [k for k in kernels if k["KernelLanguage"] == "Assembly"]
+    if len(assemblyKernels) == 0:
+        return []
+
+    archKernelMap = collections.defaultdict(list)
+    for k in assemblyKernels:
+        archKernelMap[tuple(k["ISA"])].append(k)
+
+    coFiles = []
+    for arch, archKernels in archKernelMap.items():
+        gfx = gfxName(arch)
+        objectFiles = [
+            str(asmDir / (writer.getKernelFileBase(k) + extObj))
+            for k in archKernels
+            if "codeObjectFile" not in k
+        ]
+
+        if countAsmKernels(archKernels) == 0:
+            continue
+
+        if (
+            globalParameters["MergeFiles"]
+            or globalParameters["NumMergedFiles"] > 1
+            or globalParameters["LazyLibraryLoading"]
+        ):
+
+            # Group kernels from placeholder libraries
+            coFileMap = collections.defaultdict(list)
+
+            if len(objectFiles):
+                coFileMap[asmDir / ("TensileLibrary_" + gfx + extCoRaw)] = objectFiles
+
+            for kernel in archKernels:
+                coName = kernel.get("codeObjectFile", None)
+                if coName:
+                    coFileMap[asmDir / (coName + extCoRaw)].append(
+                        str(asmDir / (writer.getKernelFileBase(kernel) + extObj))
+                    )
+
+            for coFileRaw, objFiles in coFileMap.items():
+
+                _linkIntoCodeObject(objFiles, coFileRaw, writer)
+                coFile = destDir / coFileRaw.name.replace(extCoRaw, extCo)
+                compressCodeObject(coFileRaw, coFile, gfx, bundler)
+                coFiles.append(coFile)
+
+        else:
+            # no mergefiles
+            assemblyKernelNames = [writer.getKernelFileBase(k) for k in archKernels]
+            origCOFiles = [os.path.join(asmDir, k + ".co") for k in assemblyKernelNames]
+            newCOFiles = [os.path.join(destDir, k + "_" + gfx + ".co") for k in assemblyKernelNames]
+
+            for src, dst in (
+                zip(origCOFiles, newCOFiles)
+                if globalParameters["PrintLevel"] == 0
+                else Utils.tqdm(zip(origCOFiles, newCOFiles), desc="Relocating code objects")
+            ):
+                shutil.copyfile(src, dst)
+            coFiles += newCOFiles
+            printWarning("Code object files are not compressed in `--no-merge-files` build mode.")
+
+    return coFiles

--- a/Tensile/BuildCommands/AssemblyCommands.py
+++ b/Tensile/BuildCommands/AssemblyCommands.py
@@ -1,14 +1,12 @@
 import collections
-import math
 import os
 import shutil
 import subprocess
-
 from pathlib import Path
 from typing import List, Union
 
 from .. import Utils
-from ..Common import globalParameters, tPrint, ensurePath, printWarning, gfxName
+from ..Common import ensurePath, gfxName, globalParameters, printWarning, tPrint
 from ..KernelWriterAssembly import KernelWriterAssembly
 from ..SolutionStructs import Solution
 from .SharedCommands import compressCodeObject

--- a/Tensile/BuildCommands/SharedCommands.py
+++ b/Tensile/BuildCommands/SharedCommands.py
@@ -1,0 +1,41 @@
+import subprocess
+
+from typing import Union
+from pathlib import Path
+
+from ..Common import tPrint
+
+
+def compressCodeObject(
+    coPathSrc: Union[Path, str], coPathDest: Union[Path, str], gfx: str, bundler: str
+):
+    """Compresses a code object file using the provided bundler.
+
+    Args:
+        coPathSrc: The source path of the code object file to be compressed.
+        coPathDest: The destination path for the compressed code object file.
+        gfx: The target GPU architecture.
+        bundler: The path to the Clang Offload Bundler executable.
+
+    Raises:
+        RuntimeError: If compressing the code object file fails.
+    """
+    args = [
+        bundler,
+        "--compress",
+        "--type=o",
+        "--bundle-align=4096",
+        f"--targets=host-x86_64-unknown-linux,hipv4-amdgcn-amd-amdhsa--{gfx}",
+        "--input=/dev/null",
+        f"--input={str(coPathSrc)}",
+        f"--output={str(coPathDest)}",
+    ]
+
+    tPrint(2, f"Bundling/compressing code objects: {' '.join(args)}")
+    try:
+        out = subprocess.check_output(args, stderr=subprocess.STDOUT)
+        tPrint(2, f"Output: {out}")
+    except subprocess.CalledProcessError as err:
+        raise RuntimeError(
+            f"Error compressing code object via bundling: {err.output}\nFailed command: {' '.join(args)}"
+        )

--- a/Tensile/BuildCommands/SharedCommands.py
+++ b/Tensile/BuildCommands/SharedCommands.py
@@ -1,7 +1,6 @@
 import subprocess
-
-from typing import Union
 from pathlib import Path
+from typing import Union
 
 from ..Common import tPrint
 

--- a/Tensile/BuildCommands/SourceCommands.py
+++ b/Tensile/BuildCommands/SourceCommands.py
@@ -1,0 +1,233 @@
+import itertools
+import os
+import re
+import shlex
+import subprocess
+
+from typing import Union, List
+from pathlib import Path
+
+from ..Common import (
+    globalParameters,
+    tPrint,
+    ensurePath,
+    supportedCompiler,
+    ParallelMap,
+    splitArchs,
+    which,
+    ParallelMap,
+    IsaVersion,
+)
+from .SharedCommands import compressCodeObject
+
+
+def _compileSourceObjectFile(
+    cmdlineArchs: List[str],
+    cxxCompiler: str,
+    cxxSrcPath: str,
+    objDestPath: str,
+    outputPath: str,
+    compilerVer: IsaVersion,
+):
+    """
+    Compiles a HIP source file (.cpp) into an object file (.o).
+
+    Args:
+        cmdlineArchs: List of architectures for offloading.
+        cxxCompiler: The C++ compiler to use.
+        kernelFile: The path to the kernel source file.
+        buildPath: The build directory path.
+        objFilename: The name of the output object file.
+        outputPath: The output directory path.
+        globalParameters (dict): A dictionary of global parameters.
+
+    Raises:
+        subprocess.CalledProcessError: If the compilation command fails.
+    """
+    archFlags = ["--offload-arch=" + arch for arch in cmdlineArchs]
+
+    # needs to be fixed when Maneesh's change is made available
+    hipFlags = ["-D__HIP_HCC_COMPAT_MODE__=1"]
+    hipFlags += (
+        ["--genco"] if cxxCompiler == "hipcc" else ["--cuda-device-only", "-x", "hip", "-O3"]
+    )
+    hipFlags += ["-I", outputPath]
+
+    if len(compilerVer) >= 2 and (
+        compilerVer[0] > 5 or (compilerVer[0] == 5 and compilerVer[1] > 2)
+    ):
+        hipFlags += ["-Xoffload-linker", "--build-id"]
+
+    launcher = shlex.split(os.environ.get("Tensile_CXX_COMPILER_LAUNCHER", ""))
+
+    if os.name == "nt":
+        hipFlags += [
+            "-std=c++14",
+            "-fms-extensions",
+            "-fms-compatibility",
+            "-fPIC",
+            "-Wno-deprecated-declarations",
+        ]
+
+    args = (
+        launcher
+        + [which(cxxCompiler)]
+        + hipFlags
+        + archFlags
+        + [str(cxxSrcPath), "-c", "-o", objDestPath]
+    )
+
+    tPrint(2, f"Compile source object file command: {args}")
+    try:
+        out = subprocess.check_output(args, stderr=subprocess.STDOUT)
+        tPrint(2, f"Output: {out}" if out else "")
+    except subprocess.CalledProcessError as err:
+        raise RuntimeError(
+            f"Error compiling source object file: {err.output}\nFailed command: {' '.join(args)}"
+        )
+
+
+def _computeSourceCodeObjectPath(target: str, base: str, buildPath: Union[Path, str], arch) -> Path:
+    """
+    Generates the output file path based on the target, base, and build path.
+
+    Args:
+        target (str): The target architecture string.
+        base (str): The base name for the output file.
+        buildPath (str): The build directory path.
+
+    Returns:
+        str: The generated output file path.
+    """
+    coPath = None
+    buildPath = Path(buildPath)
+    if "TensileLibrary" in base and "fallback" in base:
+        coPath = buildPath / "{0}_{1}.hsaco.raw".format(base, arch)
+    elif "TensileLibrary" in base:
+        variant = [t for t in ["", "xnack-", "xnack+"] if t in target][-1]
+        baseVariant = base + "-" + variant if variant else base
+        if arch in baseVariant:
+            coPath = buildPath / (baseVariant + ".hsaco.raw")
+        else:
+            raise RuntimeError(
+                "Failed to compute code object name:"
+                f"Could not find variant {variant} in {baseVariant}"
+            )
+    else:
+        coPath = buildPath / "{0}.so-000-{1}.hsaco.raw".format(base, arch)
+    return coPath
+
+
+def _listTargetTriples(bundler: str, infile: str):
+    args = [bundler, "--type=o", f"--input={infile}", "-list"]
+    try:
+        listing = subprocess.check_output(args, stderr=subprocess.STDOUT).decode().split("\n")
+    except subprocess.CalledProcessError as err:
+        raise RuntimeError(
+            f"Error listing target triples in object files: {err.output}\nFailed command: {' '.join(args)}"
+        )
+    return listing
+
+
+def _unbundleSourceCodeObjects(bundler: str, target: str, infile: str, outfileRaw: str):
+    """
+    Unbundles source code object files using the Clang Offload Bundler.
+
+    Args:
+        bundler (str): The path to the Clang Offload Bundler executable.
+        target (str): The target architecture string.
+        inflag (str): The input flag for the bundler.
+        infile (str): The input file path.
+        outflag (str): The output flag for the bundler.
+        outfileRaw (str): The output raw file path.
+
+    Raises:
+        RuntimeError: If unbundling the source code object file fails.
+    """
+    args = [
+        bundler,
+        "--type=o",
+        f"--targets={target}",
+        f"--input={infile}",
+        f"--output={outfileRaw}",
+        "--unbundle",
+    ]
+
+    tPrint(2, "Unbundling source code object file: " + " ".join(args))
+    try:
+        out = subprocess.check_output(args, stderr=subprocess.STDOUT)
+        tPrint(2, f"Output: {out}" if out else "")
+    except subprocess.CalledProcessError as err:
+        raise RuntimeError(
+            f"Error unbundling source code object file: {err.output}\nFailed command: {' '.join(args)}"
+        )
+
+
+def _buildSourceCodeObjectFile(
+    cxxCompiler: str,
+    outputPath: Union[Path, str],
+    kernelFile: Union[Path, str],
+    removeTemporaries: bool,
+):
+
+    buildPath = Path(ensurePath(os.path.join(globalParameters["WorkingPath"], "code_object_tmp")))
+    destPath = Path(ensurePath(os.path.join(outputPath, "library")))
+    kernelPath = Path(kernelFile)
+
+    objectFilename = kernelPath.stem + ".o"
+    coPathsRaw = []
+    coPaths = []
+
+    if "CmakeCxxCompiler" in globalParameters and globalParameters["CmakeCxxCompiler"] is not None:
+        os.environ["CMAKE_CXX_COMPILER"] = globalParameters["CmakeCxxCompiler"]
+
+    if not supportedCompiler(cxxCompiler):
+        raise RuntimeError(
+            f"Cannot compiler source code object files: unknown compiler: {cxxCompiler}"
+        )
+
+    _, cmdlineArchs = splitArchs()
+
+    # Add build-id for builds with rocm 5.3+
+    compilerVer = globalParameters["HipClangVersion"].split(".")[:2]
+    compilerVer = [int(c) for c in compilerVer]
+
+    objPath = str(buildPath / objectFilename)
+    _compileSourceObjectFile(
+        cmdlineArchs, cxxCompiler, kernelFile, objPath, outputPath, compilerVer
+    )
+
+    bundler = globalParameters["ClangOffloadBundlerPath"]
+    if not bundler:
+        raise RuntimeError(
+            "No bundler found; set TENSILE_ROCM_OFFLOAD_BUNDLER_PATH to point to clang-offload-bundler"
+        )
+
+    for target in _listTargetTriples(bundler, objPath):
+        if match := re.search("gfx.*$", target):
+            arch = re.sub(":", "-", match.group())
+            coPathRaw = _computeSourceCodeObjectFilename(target, kernelPath.stem, buildPath, arch)
+            _unbundleSourceCodeObjects(bundler, target, objPath, coPathRaw)
+
+            outfile = os.path.join(destPath, coPathRaw.stem)
+            compressCodeObject(coPathRaw, outfile, arch, bundler)
+            coPathsRaw.append(coPathRaw)
+            coPaths.append(outfile)
+
+    if removeTemporaries:
+        for file in coPathsRaw:
+            os.remove(file)
+
+    return coPathsRaw
+
+
+def buildSourceCodeObjectFiles(CxxCompiler, kernelFiles, outputPath, removeTemporaries):
+    args = zip(
+        itertools.repeat(CxxCompiler),
+        itertools.repeat(outputPath),
+        kernelFiles,
+        itertools.repeat(removeTemporaries),
+    )
+    coFiles = ParallelMap(_buildSourceCodeObjectFile, args, "Compiling source kernels")
+
+    return itertools.chain.from_iterable(coFiles)

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -34,9 +34,7 @@ import collections
 import itertools
 import os
 import re
-import shlex
 import shutil
-import subprocess
 import sys
 import time
 import warnings
@@ -45,6 +43,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
 from . import ClientExecutable, Common, EmbeddedData, LibraryIO, Utils
+from .BuildCommands import AssemblyCommands, SourceCommands
 from .Common import (
     HR,
     CHeader,
@@ -56,10 +55,9 @@ from .Common import (
     globalParameters,
     printExit,
     printWarning,
+    splitArchs,
     supportedCompiler,
     tPrint,
-    which,
-    splitArchs,
 )
 from .KernelWriterAssembly import KernelWriterAssembly
 from .KernelWriterBase import KernelWriterBase
@@ -71,7 +69,6 @@ from .TensileCreateLib.ParseArguments import parseArguments
 from .Utilities.Profile import profile
 from .Utilities.String import splitDelimitedString
 from .Utilities.toFile import toFile
-from .BuildCommands import SourceCommands, AssemblyCommands
 
 TENSILE_MANIFEST_FILENAME = "TensileManifest.txt"
 TENSILE_LIBRARY_DIR = "library"
@@ -458,6 +455,7 @@ def writeKernelHelpers(
 def writeKernels(
     outputPath: str,
     cxxCompiler: str,
+    bundler: str,
     params: Dict[str, Any],
     solutions: List[Solution],
     kernels: List[Solution],
@@ -539,6 +537,7 @@ def writeKernels(
             cxxCompiler, kernelFiles, outputPath, removeTemporaries
         )
         codeObjectFiles += AssemblyCommands.buildAssemblyCodeObjectFiles(
+            bundler,
             kernelsToBuild,
             kernelWriterAssembly,
             outputPath,
@@ -1117,6 +1116,7 @@ def writeBenchmarkClientFiles(
     codeObjectFiles, kernels, solutions = writeKernels(
         libraryWorkingPath,
         cxxCompiler,
+        globalParameters["ClangOffloadBundler"],
         globalParameters,
         solutions,
         kernels,
@@ -1485,6 +1485,7 @@ def TensileCreateLibrary():
     codeObjectFiles, kernels, solutions = writeKernels(
         outputPath,
         cxxCompiler,
+        globalParameters["ClangOffloadBundlerPath"],
         args,
         solutions,
         kernels,

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -59,6 +59,7 @@ from .Common import (
     supportedCompiler,
     tPrint,
     which,
+    splitArchs,
 )
 from .KernelWriterAssembly import KernelWriterAssembly
 from .KernelWriterBase import KernelWriterBase
@@ -70,12 +71,13 @@ from .TensileCreateLib.ParseArguments import parseArguments
 from .Utilities.Profile import profile
 from .Utilities.String import splitDelimitedString
 from .Utilities.toFile import toFile
+from .BuildCommands import SourceCommands, AssemblyCommands
 
 TENSILE_MANIFEST_FILENAME = "TensileManifest.txt"
 TENSILE_LIBRARY_DIR = "library"
 
-
 ProcessedKernelResult = Tuple[int, str, str, str, Optional[str]]
+ProcessedKernelLookup = Dict[str, List[ProcessedKernelResult]]
 
 
 def processKernelSource(kernel, kernelWriterSource, kernelWriterAssembly) -> ProcessedKernelResult:
@@ -103,312 +105,6 @@ def processKernelSource(kernel, kernelWriterSource, kernelWriterAssembly) -> Pro
     return (err, src, header, kernelName, filename)
 
 
-def getAssemblyCodeObjectFiles(kernels, kernelWriterAssembly, outputPath, removeTemporaries):
-    destDir = ensurePath(os.path.join(outputPath, "library"))
-    asmDir = kernelWriterAssembly.getAssemblyDirectory()
-    assemblyKernels = list([k for k in kernels if k["KernelLanguage"] == "Assembly"])
-    if len(assemblyKernels) == 0:
-        return []
-
-    archs = collections.defaultdict(list)
-    for k in assemblyKernels:
-        archs[tuple(k["ISA"])].append(k)
-    coFiles = []
-    for arch, archKernels in archs.items():
-        archName = gfxName(arch)
-        objectFiles = list(
-            [
-                kernelWriterAssembly.getKernelFileBase(k) + ".o"
-                for k in archKernels
-                if "codeObjectFile" not in k
-            ]
-        )
-
-        numObjectFiles = len([1 for k in archKernels if k["KernelLanguage"] == "Assembly"])
-
-        if numObjectFiles == 0:
-            continue
-        if (
-            globalParameters["MergeFiles"]
-            or globalParameters["NumMergedFiles"] > 1
-            or globalParameters["LazyLibraryLoading"]
-        ):
-
-            # Group kernels from placeholder libraries
-            coFileMap = collections.defaultdict(list)
-
-            if len(objectFiles):
-                coFileMap[os.path.join(destDir, "TensileLibrary_" + archName + ".co")] = objectFiles
-
-            for kernel in archKernels:
-                coName = kernel.get("codeObjectFile", None)
-                if coName:
-                    coFileMap[os.path.join(destDir, coName + ".co")] += [
-                        kernelWriterAssembly.getKernelFileBase(kernel) + ".o"
-                    ]
-
-            for coFile, objectFiles in coFileMap.items():
-                args = []
-                if os.name == "nt":
-                    # On Windows, the objectFiles list command line (including spaces)
-                    # exceeds the limit of 8191 characters, so using response file
-
-                    responseArgs = objectFiles
-                    responseFile = os.path.join(asmDir, "clangArgs.txt")
-                    with open(responseFile, "wt") as file:
-                        file.write(" ".join(responseArgs))
-                        file.flush()
-
-                    args = kernelWriterAssembly.getLinkCodeObjectArgs(["@clangArgs.txt"], coFile)
-                else:
-                    args = kernelWriterAssembly.getLinkCodeObjectArgs(objectFiles, coFile)
-
-                tPrint(2, "Linking objects into co files: " + " ".join(args))
-
-                # change to use  check_output to force windows cmd block util command finish
-                try:
-                    out = subprocess.check_output(args, stderr=subprocess.STDOUT, cwd=asmDir)
-                    tPrint(3, out)
-                except subprocess.CalledProcessError as err:
-                    print(err.output)
-                    raise
-
-                coFiles.append(coFile)
-        else:
-            # no mergefiles
-
-            assemblyKernelNames = [kernelWriterAssembly.getKernelFileBase(k) for k in archKernels]
-            origCOFiles = [os.path.join(asmDir, k + ".co") for k in assemblyKernelNames]
-            newCOFiles = [
-                os.path.join(destDir, k + "_" + archName + ".co") for k in assemblyKernelNames
-            ]
-
-            for src, dst in (
-                zip(origCOFiles, newCOFiles)
-                if globalParameters["PrintLevel"] == 0
-                else Utils.tqdm(zip(origCOFiles, newCOFiles), desc="Relocating code objects")
-            ):
-                shutil.copyfile(src, dst)
-            coFiles += newCOFiles
-
-    return coFiles
-
-
-def splitArchs():
-    # Helper for architecture
-    def isSupported(arch):
-        return (
-            globalParameters["AsmCaps"][arch]["SupportedISA"]
-            and globalParameters["AsmCaps"][arch]["SupportedSource"]
-        )
-
-    if ";" in globalParameters["Architecture"]:
-        wantedArchs = globalParameters["Architecture"].split(";")
-    else:
-        wantedArchs = globalParameters["Architecture"].split("_")
-    archs = []
-    cmdlineArchs = []
-
-    if "all" in wantedArchs:
-        for arch in globalParameters["SupportedISA"]:
-            if isSupported(arch):
-                if arch == (9, 0, 6) or arch == (9, 0, 8) or arch == (9, 0, 10):
-                    if arch == (9, 0, 10):
-                        archs += [gfxName(arch) + "-xnack+"]
-                        cmdlineArchs += [gfxName(arch) + ":xnack+"]
-                    archs += [gfxName(arch) + "-xnack-"]
-                    cmdlineArchs += [gfxName(arch) + ":xnack-"]
-                else:
-                    archs += [gfxName(arch)]
-                    cmdlineArchs += [gfxName(arch)]
-    else:
-        for arch in wantedArchs:
-            archs += [re.sub(":", "-", arch)]
-            cmdlineArchs += [arch]
-    return archs, cmdlineArchs
-
-
-def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile, removeTemporaries):
-    buildPath = ensurePath(os.path.join(globalParameters["WorkingPath"], "code_object_tmp"))
-    destDir = ensurePath(os.path.join(outputPath, "library"))
-    (_, filename) = os.path.split(kernelFile)
-    (base, _) = os.path.splitext(filename)
-
-    if "CmakeCxxCompiler" in globalParameters and globalParameters["CmakeCxxCompiler"] is not None:
-        os.environ["CMAKE_CXX_COMPILER"] = globalParameters["CmakeCxxCompiler"]
-
-    objectFilename = base + ".o"
-    soFilename = base + ".so"
-
-    coFilenames = []
-
-    if supportedCompiler(CxxCompiler):
-        archs, cmdlineArchs = splitArchs()
-
-        archFlags = ["--offload-arch=" + arch for arch in cmdlineArchs]
-
-        # needs to be fixed when Maneesh's change is made available
-        hipFlags = ["-D__HIP_HCC_COMPAT_MODE__=1"]
-        hipFlags += (
-            ["--genco"] if CxxCompiler == "hipcc" else ["--cuda-device-only", "-x", "hip", "-O3"]
-        )
-        # if CxxCompiler == "amdclang++":
-        # hipFlags += ["-mllvm", "-amdgpu-early-inline-all=true", "-mllvm", "-amdgpu-function-calls=false"]
-        hipFlags += ["-I", outputPath]
-
-        # Add build-id for builds with rocm 5.3+
-        compilerVer = globalParameters["HipClangVersion"].split(".")[:2]
-        compilerVer = [int(c) for c in compilerVer]
-        if len(compilerVer) >= 2 and (
-            compilerVer[0] > 5 or (compilerVer[0] == 5 and compilerVer[1] > 2)
-        ):
-            hipFlags += ["-Xoffload-linker", "--build-id"]
-
-        launcher = shlex.split(os.environ.get("Tensile_CXX_COMPILER_LAUNCHER", ""))
-
-        if os.name == "nt":
-            hipFlags += [
-                "-std=c++14",
-                "-fms-extensions",
-                "-fms-compatibility",
-                "-fPIC",
-                "-Wno-deprecated-declarations",
-            ]
-            compileArgs = (
-                launcher
-                + [which(CxxCompiler)]
-                + hipFlags
-                + archFlags
-                + [kernelFile, "-c", "-o", os.path.join(buildPath, objectFilename)]
-            )
-        else:
-            compileArgs = (
-                launcher
-                + [which(CxxCompiler)]
-                + hipFlags
-                + archFlags
-                + [kernelFile, "-c", "-o", os.path.join(buildPath, objectFilename)]
-            )
-
-        tPrint(2, f"Build object file command: {compileArgs}")
-        # change to use  check_output to force windows cmd block util command finish
-        try:
-            out = subprocess.check_output(compileArgs, stderr=subprocess.STDOUT)
-            tPrint(3, out)
-        except subprocess.CalledProcessError as err:
-            print(err.output)
-            raise
-
-        # get hipcc version due to compatiblity reasons
-        # If we aren't using hipcc what happens?
-        hipccver = globalParameters["HipClangVersion"].split(".")
-        hipccMaj = int(hipccver[0])
-        hipccMin = int(hipccver[1])
-
-        # for hipclang 5.2 and above, clang offload bundler changes the way input/output files are specified
-        inflag = "-inputs"
-        outflag = "-outputs"
-        if (hipccMaj == 5 and hipccMin >= 2) or hipccMaj >= 6:
-            inflag = "-input"
-            outflag = "-output"
-
-        infile = os.path.join(buildPath, objectFilename)
-        bundler = globalParameters["ClangOffloadBundlerPath"]
-        if bundler is None:
-            raise ValueError(
-                "No bundler available; set TENSILE_ROCM_OFFLOAD_BUNDLER_PATH to point to clang-offload-bundler."
-            )
-        try:
-            bundlerArgs = [bundler, "-type=o", "%s=%s" % (inflag, infile), "-list"]
-            listing = (
-                subprocess.check_output(bundlerArgs, stderr=subprocess.STDOUT).decode().split("\n")
-            )
-            for target in listing:
-                matched = re.search("gfx.*$", target)
-                if matched:
-                    arch = re.sub(":", "-", matched.group())
-                    if "TensileLibrary" in base and "fallback" in base:
-                        outfile = os.path.join(buildPath, "{0}_{1}.hsaco".format(base, arch))
-                    elif "TensileLibrary" in base:
-                        variant = [t for t in ["", "xnack-", "xnack+"] if t in target][-1]
-                        baseVariant = base + "-" + variant if variant else base
-                        if arch in baseVariant:
-                            outfile = os.path.join(buildPath, baseVariant + ".hsaco")
-                        else:
-                            outfile = None
-                    else:
-                        outfile = os.path.join(
-                            buildPath, "{0}-000-{1}.hsaco".format(soFilename, arch)
-                        )
-
-                    # Compilation
-                    if outfile:
-                        coFilenames.append(os.path.split(outfile)[1])
-                        # bundlerArgs = [bundler, "-type=o", "-targets=%s" % target, "-inputs=%s" % infile, "-outputs=%s" % outfile, "-unbundle"]
-                        bundlerArgs = [
-                            bundler,
-                            "-type=o",
-                            "-targets=%s" % target,
-                            "%s=%s" % (inflag, infile),
-                            "%s=%s" % (outflag, outfile),
-                            "-unbundle",
-                        ]
-                        tPrint(2, "Build source code object file: " + " ".join(bundlerArgs))
-                        # change to use  check_output to force windows cmd block util command finish
-                        out = subprocess.check_output(bundlerArgs, stderr=subprocess.STDOUT)
-                        tPrint(3, out)
-
-        except subprocess.CalledProcessError as err:
-            tPrint(1, err.output)
-            for i in range(len(archs)):
-                outfile = os.path.join(buildPath, "{0}-000-{1}.hsaco".format(soFilename, archs[i]))
-                coFilenames.append(os.path.split(outfile)[1])
-                # bundlerArgs = [bundler, "-type=o", "-targets=hip-amdgcn-amd-amdhsa--%s" % cmdlineArchs[i], "-inputs=%s" % infile, "-outputs=%s" % outfile, "-unbundle"]
-                bundlerArgs = [
-                    bundler,
-                    "-type=o",
-                    "-targets=hip-amdgcn-amd-amdhsa--%s" % cmdlineArchs[i],
-                    "%s=%s" % (inflag, infile),
-                    "%s=%s" % (outflag, outfile),
-                    "-unbundle",
-                ]
-                tPrint(2, "Build source code object file: " + " ".join(bundlerArgs))
-                # change to use  check_output to force windows cmd block util command finish
-                try:
-                    out = subprocess.check_output(bundlerArgs, stderr=subprocess.STDOUT)
-                    tPrint(3, out)
-                except subprocess.CalledProcessError as err:
-                    tPrint(1, err.output)
-                    raise
-
-    else:
-        raise RuntimeError("Unknown compiler {}".format(CxxCompiler))
-
-    coFilenames = [name for name in coFilenames]
-    extractedCOs = [os.path.join(buildPath, name) for name in coFilenames]
-    destCOsList = [os.path.join(destDir, name) for name in coFilenames]
-    for src, dst in zip(extractedCOs, destCOsList):
-        if removeTemporaries:
-            shutil.move(src, dst)
-        else:
-            shutil.copyfile(src, dst)
-
-    return destCOsList
-
-
-def buildSourceCodeObjectFiles(CxxCompiler, kernelFiles, outputPath, removeTemporaries):
-    args = zip(
-        itertools.repeat(CxxCompiler),
-        itertools.repeat(outputPath),
-        kernelFiles,
-        itertools.repeat(removeTemporaries),
-    )
-    coFiles = Common.ParallelMap(buildSourceCodeObjectFile, args, "Compiling source kernels")
-
-    return itertools.chain.from_iterable(coFiles)
-
-
-################################################################################
 def prepAsm(
     kernelWriterAssembly: KernelWriterAssembly,
     isLinux: bool,
@@ -484,9 +180,6 @@ def prepAsm(
             assemblerFile.write(f"{lArgs}\n")
             assemblerFile.write("copy %f%.co ..\..\..\library\%f%_%h%.co\n")
     os.chmod(assemblerFileName, 0o777)
-
-
-ProcessedKernelLookup = Dict[str, Any]
 
 
 def collectFilesToWrite(
@@ -842,10 +535,10 @@ def writeKernels(
 
     codeObjectFiles = []
     if not globalParameters["GenerateSourcesAndExit"]:
-        codeObjectFiles += buildSourceCodeObjectFiles(
+        codeObjectFiles += SourceCommands.buildSourceCodeObjectFiles(
             cxxCompiler, kernelFiles, outputPath, removeTemporaries
         )
-        codeObjectFiles += getAssemblyCodeObjectFiles(
+        codeObjectFiles += AssemblyCommands.buildAssemblyCodeObjectFiles(
             kernelsToBuild,
             kernelWriterAssembly,
             outputPath,

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,12 @@ deps =
 commands =
     invoke hostlibtest --clean --configure --build
 
+[testenv:docs]
+skip_install = true
+change_dir = {toxinidir}/docs
+deps = -r docs/sphinx/requirements.txt 
+commands = python3 -m sphinx -T -b html -d _build/doctrees -D language=en -v . _build/html
+
 [testenv:lint]
 skip_install = true
 deps =
@@ -64,16 +70,11 @@ commands =
       {toxinidir}/Tensile/Parallel.py \
       {toxinidir}/Tensile/TensileCreateLibrary.py \
       {toxinidir}/Tensile/TensileCreateLib/ \
+      {toxinidir}/Tensile/BuildCommands/ \
       {toxinidir}/Tensile/Tests/unit/test_TensileCreateLibrary.py \
       {toxinidir}/Tensile/Tests/unit/test_KernelFileContext.py \
       {toxinidir}/Tensile/Tests/unit/test_AsmRegisterPool.py \
       {posargs}
-
-[testenv:docs]
-skip_install = true
-change_dir = {toxinidir}/docs
-deps = -r docs/sphinx/requirements.txt 
-commands = python3 -m sphinx -T -b html -d _build/doctrees -D language=en -v . _build/html
 
 [testenv:isort]
 description = "Sorts import statements for less merge conflicts"
@@ -86,6 +87,7 @@ commands =
       {toxinidir}/Tensile/Parallel.py \
       {toxinidir}/Tensile/TensileCreateLibrary.py \
       {toxinidir}/Tensile/TensileCreateLib/ \
+      {toxinidir}/Tensile/BuildCommands/ \
       {toxinidir}/Tensile/Tests/unit/test_TensileCreateLibrary.py \
       {toxinidir}/Tensile/Tests/unit/test_KernelFileContext.py \
       {toxinidir}/Tensile/Tests/unit/test_AsmRegisterPool.py \


### PR DESCRIPTION
**Summary:**

This PR adds a compression layer to all final code objects, thereby generating smaller libraries at the expense of build time. Includes minor refactoring.

**Outcomes:**

- A new clang-offload-bundler invocation is added after assembly object linking.
- `getAssemblyCodeObjectFiles` has been renamed to `buildAssemblyCodeObjectFiles` to match the name of source kernel functions.

| Build | Time | Size of _build/library |
| -- | -- | -- |
| TCL, Feature, gfx900 | 1m36.450s | 29M |
| TCL, Develop, gfx900 | 1m29.974s | 76M |
| rocBLAS, Feature, all | 55m38.488s (55.64m) | 634M |
| rocBLAS, Develop, all | 54m5.789s (54.10m) | 3.7G |

Compression ratio for gfx900: 2.66
Compression ratio for gfx90a: 3.74
Compression ratio for rocBLAS: 5.83

Build time increase for rocBLAS: 2.8%

Local rocBLAS install command:
```
time ./install.sh -dc -t "$(pwd)/../Tensile/wk/bundle-compress-co-files" --debug --no_hipblaslt
```

**Testing and Environment:**

Environment: Docker, Ubuntu 24.04, ROCm 6.4 RC stack, AMD clang version 18.0.0, AMD clang-offload-bundler version 18.0.0

- [x] Tests pass for rocBLAS test client `./rocblas-test`
