### PR TITLE
use jenkins node details instead of hard coded

### DIFF
--- a/.jenkins/staticanalysis.groovy
+++ b/.jenkins/staticanalysis.groovy
@@ -109,9 +109,26 @@ def runCI =
 
 ci: {
     String urlJobName = auxiliary.getTopJobName(env.BUILD_URL)
+    def propertyList = ["compute-rocm-dkms-no-npi-hipclang":[pipelineTriggers([cron('0 1 * * 0')])],
+                        "rocm-docker":[]]
+    propertyList = auxiliary.appendPropertyList(propertyList)
 
-    properties(auxiliary.addCommonProperties([pipelineTriggers([cron('0 6 * * 6')])]))
-    stage(urlJobName) {
-        runCI([ubuntu20:['any']], urlJobName)
+    def jobNameList = ["compute-rocm-dkms-no-npi-hipclang":[]]
+    jobNameList = auxiliary.appendJobNameList(jobNameList)
+
+    propertyList.each
+    {
+        jobName, property->
+        if (urlJobName == jobName)
+            properties(auxiliary.addCommonProperties(property))
+    }
+
+    jobNameList.each
+    {
+        jobName, nodeDetails->
+        if (urlJobName == jobName)
+            stage(jobName) {
+                runCI(nodeDetails, jobName)
+            }
     }
 }


### PR DESCRIPTION

**Summary:**
Math-CI would like to change the way nodes are being assigned for staticanalysis jobs. Currently it is hard coded to ubuntu 20 & any nodes however we would like to set this in jenkins instead


**Outcomes:**
Nodes will follow xml file details in jenkins


*What testing did you do to ensure this change will integrate successfully?
Jenkins checks should all pass.
