### PR TITLE
Mark VOP3v_dot4_i32_i8 as True for 11.0.0

### DIFF
--- a/Tensile/AsmCaps.py
+++ b/Tensile/AsmCaps.py
@@ -666,7 +666,7 @@ CACHED_ASM_CAPS = \
               'MaxVmcnt': 63,
               'SupportedISA': True,
               'SupportedSource': True,
-              'VOP3v_dot4_i32_i8': False,
+              'VOP3v_dot4_i32_i8': True,
               'v_dot2_f32_f16': True,
               'v_dot2c_f32_f16': True,
               'v_dot4_i32_i8': False,


### PR DESCRIPTION
Recent versions of amdclang do not agree with capabilities cache. This change corrects one such disagreement.
