### PR TITLE
fix typo in docs/conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,7 +51,7 @@ autodoc_default_options = {
 }
 
 external_toc_path = "./sphinx/_toc.yml"
-external_projects_current_project = "Tensile"
+external_projects_current_project = "tensile"
 
 docs_core = ROCmDocs(left_nav_title)
 docs_core.setup()


### PR DESCRIPTION
**Summary:**

*What is being changed and why?*

This is a one-liner to fix docs configuration. Change `external_projects_current_project` to `tensile` from `Tensile`.

This field is case-sensitive and should match the `tensile` key in `projects.yaml` in the `rocm-docs-core utility `https://github.com/ROCm/rocm-docs-core/blob/develop/src/rocm_docs/data/projects.yaml.

**Outcomes:**

*What is the result of this change? What components of the project does it affect?*

Affects documentation builds only. This is used for https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping

**Notable changes:**

*Are there any changes that are of particular importance*?
No

**Testing and Environment:**

*What environment are you targeting (OS, ROCm version, Python versions, etc.)?*
N/A

*What testing did you do to ensure this change will integrate successfully?
N/A
