### PR TITLE
Improve default toolchain configuration

### DIFF
--- a/Tensile/BuildCommands/AssemblyCommands.py
+++ b/Tensile/BuildCommands/AssemblyCommands.py
@@ -28,12 +28,13 @@ def _linkIntoCodeObject(
     """
     args = []
     if os.name == "nt":
-        # On Windows, the objectFiles list command line (including spaces)
-        # exceeds the limit of 8191 characters, so using response file
-        with tempfile.NamedTemporaryFile(mode="wt", delete=False) as f:
-            f.write(" ".join(o.replace("\\", "/") for o in objFiles))
-            f.flush()
-            args = kernelWriterAssembly.getLinkCodeObjectArgs([f"@{f.name}"], str(coPathDest))
+        # On Windows, it is possible for the list of `objFiles` to exceed the command line limit
+        # LLVM allows the provision of compiler arguments via a "response file" (`rf` below)
+        # Reference: https://llvm.org/docs/CommandLine.html#response-files
+        with tempfile.NamedTemporaryFile(mode="wt", delete=False) as rf:
+            rf.write(" ".join(o.replace("\\", "/") for o in objFiles))
+            rf.flush()
+            args = kernelWriterAssembly.getLinkCodeObjectArgs([f"@{rf.name}"], str(coPathDest))
     else:
         args = kernelWriterAssembly.getLinkCodeObjectArgs(objFiles, str(coPathDest))
 

--- a/Tensile/BuildCommands/AssemblyCommands.py
+++ b/Tensile/BuildCommands/AssemblyCommands.py
@@ -29,13 +29,12 @@ def _linkIntoCodeObject(
     if os.name == "nt":
         # On Windows, the objectFiles list command line (including spaces)
         # exceeds the limit of 8191 characters, so using response file
-
-        responseFile = os.path.join("/tmp", "clangArgs.txt")
+        responseFile = os.path.join(Path.cwd(), "clang_args.txt")
         with open(responseFile, "wt") as file:
             file.write(" ".join(objFiles))
             file.flush()
 
-        args = kernelWriterAssembly.getLinkCodeObjectArgs(["@clangArgs.txt"], str(coPathDest))
+        args = kernelWriterAssembly.getLinkCodeObjectArgs(["@clang_args.txt"], str(coPathDest))
     else:
         args = kernelWriterAssembly.getLinkCodeObjectArgs(objFiles, str(coPathDest))
 

--- a/Tensile/BuildCommands/AssemblyCommands.py
+++ b/Tensile/BuildCommands/AssemblyCommands.py
@@ -32,7 +32,8 @@ def _linkIntoCodeObject(
         # LLVM allows the provision of compiler arguments via a "response file" (`rf` below)
         # Reference: https://llvm.org/docs/CommandLine.html#response-files
         with tempfile.NamedTemporaryFile(mode="wt", delete=False) as rf:
-            rf.write(" ".join(o.replace("\\", "/") for o in objFiles))
+            # Use repr to a get raw string with non-escaped path separators
+            rf.write(" ".join(map(repr, objFiles)))
             rf.flush()
             args = kernelWriterAssembly.getLinkCodeObjectArgs([f"@{rf.name}"], str(coPathDest))
     else:

--- a/Tensile/BuildCommands/AssemblyCommands.py
+++ b/Tensile/BuildCommands/AssemblyCommands.py
@@ -2,6 +2,7 @@ import collections
 import os
 import shutil
 import subprocess
+import tempfile
 from pathlib import Path
 from typing import List, Union
 
@@ -29,12 +30,10 @@ def _linkIntoCodeObject(
     if os.name == "nt":
         # On Windows, the objectFiles list command line (including spaces)
         # exceeds the limit of 8191 characters, so using response file
-        responseFile = os.path.join(Path.cwd(), "clang_args.txt")
-        with open(responseFile, "wt") as file:
-            file.write(" ".join(objFiles))
-            file.flush()
-
-        args = kernelWriterAssembly.getLinkCodeObjectArgs(["@clang_args.txt"], str(coPathDest))
+        with tempfile.NamedTemporaryFile(mode="wt", delete=False) as f:
+            f.write(" ".join(o.replace("\\", "/") for o in objFiles))
+            f.flush()
+            args = kernelWriterAssembly.getLinkCodeObjectArgs([f"@{f.name}"], str(coPathDest))
     else:
         args = kernelWriterAssembly.getLinkCodeObjectArgs(objFiles, str(coPathDest))
 

--- a/Tensile/BuildCommands/SharedCommands.py
+++ b/Tensile/BuildCommands/SharedCommands.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 from pathlib import Path
 from typing import Union
@@ -25,7 +26,7 @@ def compressCodeObject(
         "--type=o",
         "--bundle-align=4096",
         f"--targets=host-x86_64-unknown-linux,hipv4-amdgcn-amd-amdhsa--{gfx}",
-        "--input=/dev/null",
+        f"--input={os.devnull}",
         f"--input={str(coPathSrc)}",
         f"--output={str(coPathDest)}",
     ]

--- a/Tensile/BuildCommands/SourceCommands.py
+++ b/Tensile/BuildCommands/SourceCommands.py
@@ -13,9 +13,7 @@ from ..Common import (
     ensurePath,
     globalParameters,
     splitArchs,
-    supportedCompiler,
     tPrint,
-    which,
 )
 
 
@@ -95,7 +93,7 @@ def _compileSourceObjectFile(
 
     args = (
         launcher
-        + [which(cxxCompiler)]
+        + [cxxCompiler]
         + hipFlags
         + archFlags
         + [str(cxxSrcPath), "-c", "-o", objDestPath]
@@ -178,9 +176,6 @@ def _buildSourceCodeObjectFile(
 
     if "CmakeCxxCompiler" in globalParameters and globalParameters["CmakeCxxCompiler"] is not None:
         os.environ["CMAKE_CXX_COMPILER"] = globalParameters["CmakeCxxCompiler"]
-
-    if not supportedCompiler(cxxCompiler):
-        raise RuntimeError(f"Cannot compile HIP code object files: unknown compiler: {cxxCompiler}")
 
     _, cmdlineArchs = splitArchs()
 

--- a/Tensile/BuildCommands/SourceCommands.py
+++ b/Tensile/BuildCommands/SourceCommands.py
@@ -92,11 +92,7 @@ def _compileSourceObjectFile(
         ]
 
     args = (
-        launcher
-        + [cxxCompiler]
-        + hipFlags
-        + archFlags
-        + [str(cxxSrcPath), "-c", "-o", objDestPath]
+        launcher + [cxxCompiler] + hipFlags + archFlags + [str(cxxSrcPath), "-c", "-o", objDestPath]
     )
 
     tPrint(2, f"Compile source object file command: {args}")

--- a/Tensile/ClientExecutable.py
+++ b/Tensile/ClientExecutable.py
@@ -27,7 +27,7 @@ import os
 import subprocess
 
 from . import Common
-from .Common import globalParameters, tPrint, supportedCompiler
+from .Common import globalParameters, tPrint
 from .Parallel import CPUThreadCount
 
 def cmake_path(os_path):
@@ -79,8 +79,8 @@ def clientExecutableEnvironment(builddir=None):
         builddir = os.path.join(globalParameters["OutputPath"], globalParameters["ClientBuildPath"])
     builddir = Common.ensurePath(builddir)
 
-    CxxCompiler = "clang++.exe" if ((os.name == "nt") and supportedCompiler(globalParameters['CxxCompiler'])) else globalParameters['CxxCompiler']
-    CCompiler   = "clang.exe"   if ((os.name == "nt") and supportedCompiler(globalParameters['CxxCompiler'])) else globalParameters['CCompiler']
+    CxxCompiler = globalParameters['CxxCompiler']
+    CCompiler   = globalParameters['CCompiler']
 
     options = {'CMAKE_BUILD_TYPE': globalParameters["CMakeBuildType"],
                'TENSILE_USE_MSGPACK': 'ON',

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -326,7 +326,7 @@ architectureMap = {
   'gfx1010':'navi10', 'gfx1011':'navi12', 'gfx1012':'navi14',
   'gfx1030':'navi21', 'gfx1031':'navi22', 'gfx1032':'navi23', 'gfx1034':'navi24', 'gfx1035':'rembrandt',
   'gfx1100':'navi31', 'gfx1101':'navi32', 'gfx1102':'navi33',
-  'gfx1151':'gfx1151',
+  'gfx1151':'strixhalo',
   'gfx1200':'gfx1200',
   'gfx1201':'gfx1201'
 }

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -2308,17 +2308,20 @@ def printCapTable(parameters):
 def which(p):
     if supportedCompiler(p) and 'CMAKE_CXX_COMPILER' in os.environ and os.path.isfile(os.environ['CMAKE_CXX_COMPILER']):
         return os.environ['CMAKE_CXX_COMPILER']
+    
+    systemPath = os.environ['PATH'].split(os.pathsep)
+    systemPath.append(os.environ["HIP_PATH"])
+
     if os.name == "nt":
         exes = [p+x for x in ['.exe', '', '.bat']]  # bat may be front end for file with no extension
     else:
         exes = [p+x for x in ['', '.exe', '.bat']]
-    system_path = os.environ['PATH'].split(os.pathsep)
-    for dirname in system_path+[globalParameters["ROCmBinPath"]]:
+    for dirname in systemPath+[globalParameters["ROCmBinPath"]]:
         for exe in exes:
             candidate = os.path.join(os.path.expanduser(dirname), exe)
             if os.path.isfile(candidate):
                 return candidate
-    return None
+    raise FileNotFoundError(f"Could not find {p} in PATH or HIP_PATH")
 
 
 def splitArchs():

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -2241,8 +2241,8 @@ def detectGlobalCurrentISA():
   """
   global globalParameters
 
-  if globalParameters["CurrentISA"] != (0,0,0) or not globalParameters["ROCmAgentEnumeratorPath"]:
-    return 0
+  if not (globalParameters["CurrentISA"] == (0,0,0) and globalParameters["ROCmAgentEnumeratorPath"]):
+    return -1
 
   enumerator = globalParameters["ROCmAgentEnumeratorPath"]
   process = subprocess.run([enumerator], stdout=subprocess.PIPE)

--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -326,7 +326,7 @@ architectureMap = {
   'gfx1010':'navi10', 'gfx1011':'navi12', 'gfx1012':'navi14',
   'gfx1030':'navi21', 'gfx1031':'navi22', 'gfx1032':'navi23', 'gfx1034':'navi24', 'gfx1035':'rembrandt',
   'gfx1100':'navi31', 'gfx1101':'navi32', 'gfx1102':'navi33',
-  'gfx1151':'strixhalo',
+  'gfx1151':'gfx1151',
   'gfx1200':'gfx1200',
   'gfx1201':'gfx1201'
 }
@@ -349,21 +349,6 @@ def getArchitectureName(gfxName: str) -> Optional[str]:
         return architectureMap[archKey]
     return None
 
-
-def supportedHipExe(hipExe: str) -> bool:
-  """Determines if a hip tool is supported by Tensile.
-
-  Args:
-      compiler: The name of a compiler to test for support.
-  
-  Return:
-      If supported True; otherwise, False.
-  """
-  isSupported = hipExe == "hipcc" or hipExe == "hipconfig"
-  if os.name == "nt": 
-    isSupported = (isSupported or hipExe == "hipcc.bat")
-  if not isSupported: printWarning(f"{hipExe} is unsupported for os {os.name}")
-  return isSupported
 
 ################################################################################
 # Enumerate Valid Solution Parameters

--- a/Tensile/Tensile.py
+++ b/Tensile/Tensile.py
@@ -306,14 +306,28 @@ def Tensile(userArgs):
 
     capabilitiesCache = LibraryIO.initAsmCapsCache(args.AsmCacheFile)
 
-    # assign global parameters
-    cxxCompiler, cCompiler, assembler, offloadBundler, hipconfig = validateToolchain(args.CxxCompiler, args.CCompiler, args.Assembler, args.OffloadBundler, ToolchainDefaults.HIP_CONFIG)
+    (
+        cxxCompiler,
+        cCompiler,
+        assembler,
+        offloadBundler,
+        hipconfig,
+        deviceEnumerator
+    ) = validateToolchain(
+        args.CxxCompiler,
+        args.CCompiler,
+        args.Assembler,
+        args.OffloadBundler,
+        ToolchainDefaults.HIP_CONFIG,
+        ToolchainDefaults.DEVICE_ENUMERATOR
+    )
     params = config.get("GlobalParameters", {})
     params["CxxCompiler"] = cxxCompiler
     params["CCompiler"] = cCompiler
     params["Assembler"] = assembler
     params["OffloadBundler"] = offloadBundler
     params["HipConfig"] = hipconfig
+    params["ROCmAgentEnumeratorPath"] = deviceEnumerator
     assignGlobalParameters(params, capabilitiesCache)
 
     if globalParameters["CacheAsmCaps"]:

--- a/Tensile/Tensile.py
+++ b/Tensile/Tensile.py
@@ -41,6 +41,7 @@ from . import LibraryLogic
 from . import __version__
 from datetime import datetime
 from .Utilities.Profile import profile
+from .Utilities.Toolchain import validateToolchain, ToolchainDefaults
 
 ###############################################################################
 # Execute Steps in Config
@@ -124,8 +125,33 @@ def addCommonArguments(argParser):
         help="use serial kernel and solution names")
     argParser.add_argument("--no-merge-files", dest="noMergeFiles", action="store_true", \
         help="kernels and solutions written to individual files")
-    argParser.add_argument("--cxx-compiler", dest="CxxCompiler", choices=["hipcc", 'amdclang++'], \
-        action="store", default="amdclang++", help="select which compiler to use")
+    argParser.add_argument(
+        "--cxx-compiler",
+        dest="CxxCompiler",
+        choices=[ToolchainDefaults.CXX_COMPILER, "hipcc"],
+        default=ToolchainDefaults.CXX_COMPILER,
+        type=str,
+        help="C++ compiler used when generating binaries."
+        " On linux, amdclang++ (default) or hipcc. On Windows clang++ (default) or hipcc.",
+    )
+    argParser.add_argument(
+        "--c-compiler",
+        dest="CCompiler",
+        default=ToolchainDefaults.C_COMPILER,
+        type=str,
+    )
+    argParser.add_argument(
+        "--assembler",
+        dest="Assembler",
+        default=ToolchainDefaults.ASSEMBLER,
+        type=str,
+    )
+    argParser.add_argument(
+        "--offload-bundler",
+        dest="OffloadBundler",
+        default=ToolchainDefaults.OFFLOAD_BUNDLER,
+        type=str,
+    )
     argParser.add_argument("--library-format", dest="LibraryFormat", choices=["yaml", "msgpack"], \
         action="store", help="select which library format to use")
     argParser.add_argument("--client-build-path", default=None)
@@ -281,10 +307,14 @@ def Tensile(userArgs):
     capabilitiesCache = LibraryIO.initAsmCapsCache(args.AsmCacheFile)
 
     # assign global parameters
-    if "GlobalParameters" in config:
-        assignGlobalParameters(config["GlobalParameters"], capabilitiesCache)
-    else:
-        assignGlobalParameters({}, capabilitiesCache)
+    cxxCompiler, cCompiler, assembler, offloadBundler, hipconfig = validateToolchain(args.CxxCompiler, args.CCompiler, args.Assembler, args.OffloadBundler, ToolchainDefaults.HIP_CONFIG)
+    params = config.get("GlobalParameters", {})
+    params["CxxCompiler"] = cxxCompiler
+    params["CCompiler"] = cCompiler
+    params["Assembler"] = assembler
+    params["OffloadBundler"] = offloadBundler
+    params["HipConfig"] = hipconfig
+    assignGlobalParameters(params, capabilitiesCache)
 
     if globalParameters["CacheAsmCaps"]:
         LibraryIO.writeAsmCapsCache(args.AsmCacheFile, globalParameters["AsmCaps"])

--- a/Tensile/TensileCreateLib/ParseArguments.py
+++ b/Tensile/TensileCreateLib/ParseArguments.py
@@ -28,7 +28,7 @@ from argparse import Action, ArgumentParser
 from typing import Any, Dict, List, Optional
 
 from ..Common import DeveloperWarning, architectureMap
-from ..Utilities.Toolchain import ToolchainDefaults
+from ..Utilities.Toolchain import ToolchainDefaults, validateToolchain
 
 
 class DeprecatedOption(Action):
@@ -316,7 +316,6 @@ def parseArguments(input: Optional[List[str]] = None) -> Dict[str, Any]:
         "IgnoreAsmCapCache": args.IgnoreAsmCapCache,
         "WriteMasterSolutionIndex": args.WriteMasterSolutionIndex,
         "KeepBuildTmp": args.KeepBuildTmp,
-        "ROCmAgentEnumeratorPath": not args.NoEnumerate,
     }
 
     if args.CmakeCxxCompiler:
@@ -329,5 +328,24 @@ def parseArguments(input: Optional[List[str]] = None) -> Dict[str, Any]:
 
     for k, v in args.GlobalParameters:
         arguments[k] = v
+    (
+        arguments["CxxCompiler"],
+        arguments["CCompiler"],
+        arguments["Assembler"],
+        arguments["OffloadBundler"],
+        arguments["HipConfig"],
+    ) = validateToolchain(
+        arguments["CxxCompiler"],
+        arguments["CCompiler"],
+        arguments["Assembler"],
+        arguments["OffloadBundler"],
+        ToolchainDefaults.HIP_CONFIG,
+    )
+    if args.NoEnumerate:
+        arguments["ROCmAgentEnumeratorPath"] = False
+    else:
+        arguments["ROCmAgentEnumeratorPath"] = validateToolchain(
+            ToolchainDefaults.DEVICE_ENUMERATOR
+        )
 
     return arguments

--- a/Tensile/TensileCreateLib/ParseArguments.py
+++ b/Tensile/TensileCreateLib/ParseArguments.py
@@ -316,12 +316,11 @@ def parseArguments(input: Optional[List[str]] = None) -> Dict[str, Any]:
         "IgnoreAsmCapCache": args.IgnoreAsmCapCache,
         "WriteMasterSolutionIndex": args.WriteMasterSolutionIndex,
         "KeepBuildTmp": args.KeepBuildTmp,
+        "ROCmAgentEnumeratorPath": not args.NoEnumerate,
     }
 
     if args.CmakeCxxCompiler:
         os.environ["CMAKE_CXX_COMPILER"] = args.CmakeCxxCompiler
-    if args.NoEnumerate:
-        arguments["ROCmAgentEnumeratorPath"] = False
     if args.GenerateSourcesAndExit:
         # Generated sources are preserved and go into output directory
         arguments["WorkingPath"] = arguments["OutputPath"]

--- a/Tensile/TensileCreateLib/ParseArguments.py
+++ b/Tensile/TensileCreateLib/ParseArguments.py
@@ -28,6 +28,7 @@ from argparse import Action, ArgumentParser
 from typing import Any, Dict, List, Optional
 
 from ..Common import DeveloperWarning, architectureMap
+from ..Utilities.Toolchain import ToolchainDefaults
 
 
 class DeprecatedOption(Action):
@@ -71,15 +72,32 @@ def parseArguments(input: Optional[List[str]] = None) -> Dict[str, Any]:
     )
 
     # Optional arguments
-    compilerChoices = ["amdclang++", "hipcc"] if os.name != "nt" else ["clang++", "hipcc"]
     parser.add_argument(
         "--cxx-compiler",
         dest="CxxCompiler",
-        choices=compilerChoices,
-        default=compilerChoices[0],
+        choices=[ToolchainDefaults.CXX_COMPILER, "hipcc"],
+        default=ToolchainDefaults.CXX_COMPILER,
         type=str,
         help="C++ compiler used when generating binaries."
         " On linux, amdclang++ (default) or hipcc. On Windows clang++ (default) or hipcc.",
+    )
+    parser.add_argument(
+        "--c-compiler",
+        dest="CCompiler",
+        default=ToolchainDefaults.C_COMPILER,
+        type=str,
+    )
+    parser.add_argument(
+        "--assembler",
+        dest="Assembler",
+        default=ToolchainDefaults.ASSEMBLER,
+        type=str,
+    )
+    parser.add_argument(
+        "--offload-bundler",
+        dest="OffloadBundler",
+        default=ToolchainDefaults.OFFLOAD_BUNDLER,
+        type=str,
     )
     parser.add_argument(
         "--architecture",
@@ -272,6 +290,9 @@ def parseArguments(input: Optional[List[str]] = None) -> Dict[str, Any]:
         "OutputPath": args.OutputPath,
         "RuntimeLanguage": args.RuntimeLanguage,
         "CxxCompiler": args.CxxCompiler,
+        "CCompiler": args.CCompiler,
+        "Assembler": args.Assembler,
+        "OffloadBundler": args.OffloadBundler,
         "CmakeCxxCompiler": args.CmakeCxxCompiler,
         "CodeObjectVersion": args.CodeObjectVersion,
         "Architecture": args.Architecture,

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -663,9 +663,7 @@ def buildObjectFileNames(
         allSources = sourceKernelNames + kernelHelperObjNames
 
         for kernelName in allSources:
-            sourceLibFiles += [
-                "%s.so-000-%s.hsaco" % (kernelName, arch) for arch in sourceArchs
-            ]
+            sourceLibFiles += ["%s.so-000-%s.hsaco" % (kernelName, arch) for arch in sourceArchs]
     elif globalParameters["NumMergedFiles"] > 1:
         for kernelIndex in range(0, globalParameters["NumMergedFiles"]):
             sourceLibFiles += [
@@ -1380,7 +1378,21 @@ def TensileCreateLibrary():
     tPrint(3, HR)
     tPrint(3, "")
 
-    args["CxxCompiler"], args["CCompiler"], args["Assembler"], args["OffloadBundler"], args["HipConfig"] = validateToolchain(args["CxxCompiler"], args["CCompiler"], args["Assembler"], args["OffloadBundler"], ToolchainDefaults.HIP_CONFIG)
+    (
+        args["CxxCompiler"],
+        args["CCompiler"],
+        args["Assembler"],
+        args["OffloadBundler"],
+        args["HipConfig"],
+    ) = validateToolchain(
+        args["CxxCompiler"],
+        args["CCompiler"],
+        args["Assembler"],
+        args["OffloadBundler"],
+        ToolchainDefaults.HIP_CONFIG,
+    )
+    if args["ROCmAgentEnumeratorPath"] != False:
+        args["ROCmAgentEnumeratorPath"] = validateToolchain(ToolchainDefaults.DEVICE_ENUMERATOR)
     assignGlobalParameters(args)
 
     manifestFile = Path(outputPath) / TENSILE_LIBRARY_DIR / TENSILE_MANIFEST_FILENAME

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -1159,7 +1159,6 @@ def verifyManifest(manifest: Path) -> bool:
     """
     with open(manifest, mode="r") as generatedFiles:
         for f in generatedFiles.readlines():
-            tPrint(1, f"Checking file: {f}")
             if not Path(f.rstrip()).exists():
                 printWarning(f"File in manifest ``{f}`` not found.")
                 return False
@@ -1435,9 +1434,6 @@ def TensileCreateLibrary():
     masterLibraries = generateLogicData(
         logicFiles, args["Version"], args["PrintLevel"], args["SeparateArchitectures"]
     )
-    tPrint(1, f"# Found {len(masterLibraries)} Master Files")
-    tPrint(1, f"# {', '.join(masterLibraries.keys())}")
-
     solutions = generateSolutions(masterLibraries, args["SeparateArchitectures"])
     if lazyLoading and args["WriteMasterSolutionIndex"]:
         writeMasterSolutionIndexCSV(outputPath, masterLibraries)
@@ -1510,10 +1506,8 @@ def TensileCreateLibrary():
 
     masterFileList = generateMasterFileList(masterLibraries, supportedArchs, lazyLoading)
 
-    tPrint(1, f"# Writing {len(masterFileList)} Master Files")
-    tPrint(1, f"# {', '.join(m[0] for m in masterFileList)}")
+    tPrint(1, f"# Writing solution selection catalog(s) for {len(solutions)} architecture(s)")
     for name, lib in masterFileList:
-        tPrint(1, f"# Writing Master File: {name}")
         writeMasterFile(newLibraryDir, libraryFormat, kernelMinNaming, name, lib)
 
     if embedLibrary or args["ClientConfig"]:

--- a/Tensile/TensileCreateLibrary.py
+++ b/Tensile/TensileCreateLibrary.py
@@ -1506,7 +1506,7 @@ def TensileCreateLibrary():
 
     masterFileList = generateMasterFileList(masterLibraries, supportedArchs, lazyLoading)
 
-    tPrint(1, f"# Writing solution selection catalog(s) for {len(solutions)} architecture(s)")
+    tPrint(1, f"# Writing {len(masterFileList)} solution selection catalog(s)")
     for name, lib in masterFileList:
         writeMasterFile(newLibraryDir, libraryFormat, kernelMinNaming, name, lib)
 

--- a/Tensile/Tests/unit/test_CustomKernels.py
+++ b/Tensile/Tests/unit/test_CustomKernels.py
@@ -28,6 +28,7 @@ from Tensile.CustomKernels import getCustomKernelConfig, getCustomKernelContents
 from Tensile.BenchmarkProblems import getCustomKernelSolutionObj
 from Tensile.Common import assignGlobalParameters
 from Tensile.Utilities.ConditionalImports import yamlLoader
+from Tensile.Utilities.Toolchain import validateToolchain, ToolchainDefaults
 
 import yaml
 
@@ -74,7 +75,30 @@ def test_ReadCustomKernelConfig(objs):
 @pytest.mark.parametrize("objs", [("TestKernel", testKernelDir)])
 def test_CreateSolutionFromCustomKernel(objs):
     try:
-        assignGlobalParameters({})
+        (
+            cxxCompiler,
+            cCompiler,
+            assembler,
+            offloadBundler,
+            hipconfig,
+            deviceEnumerator
+        ) = validateToolchain(
+            ToolchainDefaults.CXX_COMPILER,
+            ToolchainDefaults.C_COMPILER,
+            ToolchainDefaults.ASSEMBLER,
+            ToolchainDefaults.OFFLOAD_BUNDLER,
+            ToolchainDefaults.HIP_CONFIG,
+            ToolchainDefaults.DEVICE_ENUMERATOR
+        )
+        params = {
+            "CxxCompiler": cxxCompiler,
+            "CCompiler": cCompiler,
+            "Assembler": assembler,
+            "OffloadBundler": offloadBundler,
+            "HipConfig": hipconfig,
+            "ROCmAgentEnumeratorPath": deviceEnumerator,
+        }
+        assignGlobalParameters(params)
 
         name, directory = objs
         solution = getCustomKernelSolutionObj(name, directory)

--- a/Tensile/Tests/unit/test_TensileCreateLibrary.py
+++ b/Tensile/Tests/unit/test_TensileCreateLibrary.py
@@ -46,6 +46,7 @@ from Tensile.KernelWriterBase import KernelWriterBase
 from Tensile.KernelWriterSource import KernelWriterSource
 from Tensile.SolutionStructs import ProblemSizes, Solution
 from Tensile.Utilities.ConditionalImports import yamlLoader
+from Tensile.Utilities.Toolchain import ToolchainDefaults, validateToolchain
 
 mylogger = logging.getLogger()
 
@@ -537,7 +538,26 @@ def setupSolutionsAndKernels(
     unittestPath,
 ) -> Tuple[List[Solution], List[Solution], KernelWriterAssembly, KernelWriterSource]:
     """Reusable logic for setting up testable solutions and kernels"""
-    Common.assignGlobalParameters({})
+
+    (cxxCompiler, cCompiler, assembler, offloadBundler, hipconfig, deviceEnumerator) = (
+        validateToolchain(
+            ToolchainDefaults.CXX_COMPILER,
+            ToolchainDefaults.C_COMPILER,
+            ToolchainDefaults.ASSEMBLER,
+            ToolchainDefaults.OFFLOAD_BUNDLER,
+            ToolchainDefaults.HIP_CONFIG,
+            ToolchainDefaults.DEVICE_ENUMERATOR,
+        )
+    )
+    params = {
+        "CxxCompiler": cxxCompiler,
+        "CCompiler": cCompiler,
+        "Assembler": assembler,
+        "OffloadBundler": offloadBundler,
+        "HipConfig": hipconfig,
+        "ROCmAgentEnumeratorPath": deviceEnumerator,
+    }
+    Common.assignGlobalParameters(params)
     _, _, _, _, _, lib = LibraryIO.parseLibraryLogicFile(
         unittestPath.parent / "test_data" / "unit" / "aldebaran_Cijk_AlikC_Bljk_ZB_GB.yaml"
     )

--- a/Tensile/Utilities/Toolchain.py
+++ b/Tensile/Utilities/Toolchain.py
@@ -1,0 +1,174 @@
+import os
+import re
+from pathlib import Path
+from typing import List, NamedTuple, Union
+from warnings import warn
+from subprocess import run, PIPE
+
+ROCM_BIN_PATH = Path("/opt/rocm/bin")
+ROCM_LLVM_BIN_PATH = Path("/opt/rocm/lib/llvm/bin")
+
+if os.name == "nt":
+    def _windowsLatestRocmBin(path: Union[Path, str]) -> Path:
+        """Get the path to the latest ROCm bin directory, on Windows.
+        
+        This function assumes that ROCm versions are differentiated with the form ``X.Y``.
+        
+        Args:
+            path: The path to the ROCm root directory, typically ``C:/Program Files/AMD/ROCm``.
+
+        Returns:
+            The path to the ROCm bin directory for the latest ROCm version.
+            Typically of the form ``C:/Program Files/AMD/ROCm/X.Y/bin``.
+        """
+        path = Path(path)
+        pattern = re.compile(r'^\d+\.\d+$')
+        versions = filter(lambda d: d.is_dir() and pattern.match(d.name), path.iterdir())
+        latest = max(versions, key=lambda d: tuple(map(int, d.name.split('.'))))
+        return latest / "bin"
+    # LLVM binaries are in the same directory as ROCm binaries on Windows
+    ROCM_BIN_PATH = _windowsLatestRocmBin("C:/Program Files/AMD/ROCm")
+    ROCM_LLVM_BIN_PATH = _windowsLatestRocmBin("C:/Program Files/AMD/ROCm")
+
+
+osSelect = lambda linux, windows: linux if os.name != "nt" else windows
+
+
+class ToolchainDefaults(NamedTuple):
+    CXX_COMPILER= osSelect(linux="amdclang++", windows="clang++.exe")
+    C_COMPILER= osSelect(linux="amdclang", windows="clang.exe")
+    OFFLOAD_BUNDLER= osSelect(linux="clang-offload-bundler", windows="clang-offload-bundler.exe")
+    ASSEMBLER = osSelect(linux="amdclang++", windows="clang++.exe")
+    HIP_CONFIG = osSelect(linux="hipconfig", windows="hipconfig")
+
+
+def _supportedComponent(component: str, targets: List[str]) -> bool:
+    isSupported = any([component == t for t in targets]) or any([Path(component).name == t for t in targets])
+    return isSupported
+
+
+def supportedCCompiler(compiler: str) -> bool:
+    """Determine if a C compiler/assembler is supported by Tensile.
+
+    Args:
+        compiler: The name of a compiler to test for support.
+
+    Return:
+        If supported True; otherwise, False.
+    """
+    return _supportedComponent(compiler, [ToolchainDefaults.C_COMPILER, "hipcc"])
+
+
+def supportedCxxCompiler(compiler: str) -> bool:
+    """Determine if a C++/HIP compiler/assembler is supported by Tensile.
+
+    Args:
+        compiler: The name of a compiler to test for support.
+
+    Return:
+        If supported True; otherwise, False.
+    """
+    return _supportedComponent(compiler, [ToolchainDefaults.CXX_COMPILER, "hipcc"])
+
+
+def supportedOffloadBundler(bundler: str) -> bool:
+    """Determine if an offload bundler is supported by Tensile.
+
+    Args:
+        bundler: The name of an offload bundler to test for support.
+
+    Return:
+        If supported True; otherwise, False.
+    """
+    return _supportedComponent(bundler, [ToolchainDefaults.OFFLOAD_BUNDLER])
+
+
+def supportedHip(smi: str) -> bool:
+    """Determine if an offload bundler is supported by Tensile.
+
+    Args:
+        bundler: The name of an offload bundler to test for support.
+
+    Return:
+        If supported True; otherwise, False.
+    """
+    return _supportedComponent(smi, [ToolchainDefaults.HIP_CONFIG])
+
+
+def _exeExists(file: Path) -> bool:
+    """Check if a file exists and is executable.
+
+    Args:
+        file: The file to check.
+
+    Returns:
+        If the file exists and is executable, True; otherwise, False
+    """
+    if os.access(file, os.X_OK):
+        if "rocm" not in map(str.lower, file.parts):
+            warn(f"Found non-ROCm install of `{file.name}`: {file}")
+        return True
+    return False
+
+
+def _validateExecutable(file: str, searchPaths: List[Path]) -> str:
+    """Validate that the given toolchain component is in the PATH and executable.
+
+    Args:
+        file: The executable to validate.
+        searchPaths: List of directories to search for the executable.
+
+    Returns:
+        The validated executable with an absolute path.
+    """
+    if not any((
+        supportedCxxCompiler(file), supportedCCompiler(file), supportedOffloadBundler(file), supportedHip(file)
+    )):
+        raise ValueError(f"{file} is not a supported toolchain component for OS: {os.name}")
+
+    if _exeExists(Path(file)): return file
+    for path in searchPaths:
+        path /= file 
+        if _exeExists(path): return str(path)
+    raise FileNotFoundError(f"`{file}` either not found or not executable in any search path: {':'.join(map(str, searchPaths))}")
+
+
+def validateToolchain(*args: str):
+    """Validate that the given toolchain components are in the PATH and executable.
+
+    Args:
+        args: List of executable toolchain components to validate.
+     
+    Returns:
+        List of validated executables with absolute paths.
+    
+    Raises:
+        ValueError: If no toolchain components are provided.
+        FileNotFoundError: If a toolchain component is not found in the PATH.
+    """
+    if not args:
+        raise ValueError("No toolchain components to validate, at least one argument is required")
+
+    searchPaths = [
+        ROCM_BIN_PATH,
+        ROCM_LLVM_BIN_PATH,
+    ] + [Path(p) for p in os.environ["PATH"].split(os.pathsep)]
+
+    out = (_validateExecutable(x, searchPaths) for x in args)
+    return next(out) if len(args) == 1 else tuple(out) 
+
+
+def getVersion(executable: str, versionFlag: str="--version", regex: str=r'version\s+([\d.]+)') -> str:
+    """Print the version of a toolchain component.
+
+    Args:
+        executable: The toolchain component to check the version of.
+        versionFlag: The flag to pass to the executable to get the version.
+    """
+    args = f'"{executable}" "{versionFlag}"'
+    try:
+        output = run(args, stdout=PIPE, shell=True).stdout.decode().strip()
+        match = re.search(regex, output, re.IGNORECASE)
+        return match.group(1) if match else "<unknown>"
+    except Exception as e:
+        raise RuntimeError(f"Failed to get version when calling {args}: {e}")

--- a/Tensile/Utilities/Toolchain.py
+++ b/Tensile/Utilities/Toolchain.py
@@ -40,6 +40,7 @@ class ToolchainDefaults(NamedTuple):
     OFFLOAD_BUNDLER= osSelect(linux="clang-offload-bundler", windows="clang-offload-bundler.exe")
     ASSEMBLER = osSelect(linux="amdclang++", windows="clang++.exe")
     HIP_CONFIG = osSelect(linux="hipconfig", windows="hipconfig")
+    DEVICE_ENUMERATOR= osSelect(linux="rocm_agent_enumerator", windows="hipinfo.exe")
 
 
 def _supportedComponent(component: str, targets: List[str]) -> bool:
@@ -84,7 +85,7 @@ def supportedOffloadBundler(bundler: str) -> bool:
 
 
 def supportedHip(smi: str) -> bool:
-    """Determine if an offload bundler is supported by Tensile.
+    """Determine if a HIP config executable is supported by Tensile.
 
     Args:
         bundler: The name of an offload bundler to test for support.
@@ -93,6 +94,18 @@ def supportedHip(smi: str) -> bool:
         If supported True; otherwise, False.
     """
     return _supportedComponent(smi, [ToolchainDefaults.HIP_CONFIG])
+
+
+def supportedDeviceEnumerator(enumerator: str) -> bool:
+    """Determine if a device enumerator is supported by Tensile.
+
+    Args:
+        bundler: The name of a device enumerator to test for support.
+
+    Return:
+        If supported True; otherwise, False.
+    """
+    return _supportedComponent(enumerator, [ToolchainDefaults.DEVICE_ENUMERATOR])
 
 
 def _exeExists(file: Path) -> bool:
@@ -122,7 +135,11 @@ def _validateExecutable(file: str, searchPaths: List[Path]) -> str:
         The validated executable with an absolute path.
     """
     if not any((
-        supportedCxxCompiler(file), supportedCCompiler(file), supportedOffloadBundler(file), supportedHip(file)
+        supportedCxxCompiler(file),
+        supportedCCompiler(file),
+        supportedOffloadBundler(file),
+        supportedHip(file),
+        supportedDeviceEnumerator(file)
     )):
         raise ValueError(f"{file} is not a supported toolchain component for OS: {os.name}")
 

--- a/Tensile/Utilities/Toolchain.py
+++ b/Tensile/Utilities/Toolchain.py
@@ -84,7 +84,7 @@ def supportedOffloadBundler(bundler: str) -> bool:
     return _supportedComponent(bundler, [ToolchainDefaults.OFFLOAD_BUNDLER])
 
 
-def supportedHip(smi: str) -> bool:
+def supportedHip(exe: str) -> bool:
     """Determine if a HIP config executable is supported by Tensile.
 
     Args:
@@ -93,7 +93,7 @@ def supportedHip(smi: str) -> bool:
     Return:
         If supported True; otherwise, False.
     """
-    return _supportedComponent(smi, [ToolchainDefaults.HIP_CONFIG])
+    return _supportedComponent(exe, [ToolchainDefaults.HIP_CONFIG])
 
 
 def supportedDeviceEnumerator(enumerator: str) -> bool:


### PR DESCRIPTION
The link command is invoked in a non-standard way, using a compile_args.txt file. Updating the directory where this file is created fixes builds on Windows. This PR also includes improvements to out-of-the-box toolchain configuration such that environment variables are no longer required for specifying assembler and offload bundler paths, particularly on Windows.

**Testing**
Clean rocBLAS installation with target architecture gfx1201 and gfx1151 (separate installation runs)

Windows
```bash
python rmake.py -a "gfx1201" --lazy-library-loading --no-merge-architectures -t "C:\Users\bstefanu\dev\Tensile" --no_hipblaslt
```
```bash
python rmake.py -a "gfx1151" -t "C:\Users\bstefanu\dev\Tensile" -i
```
Linux
```bash
./install.sh -dc -a "gfx1151;gfx1201" -i -t "/mnt/host/Tensile" --no_hipblaslt
```

**Environment:**
Windows 10, ROCm 6.2.41512, Python 3.13.1, GPU gfx1100, CMake 3.31.3