### PR TITLE
Fixes various issues in the tuneing scripts

### DIFF
--- a/tuning/automation/ExtractSizes.py
+++ b/tuning/automation/ExtractSizes.py
@@ -731,6 +731,8 @@ def ConvertToRocBlasBenchCall(line):
     sameParams = set(['b_type','c_type','d_type','compute_type','lda','ldb','ldc','ldd','batch','batch_count','algo','solution_index','flags','stride_a','stride_b','stride_c','stride_d','alpha','beta'])
 
     for item in range(2,len(line)):
+        if line[item] == 'flags' and line[item+1] == 'none':
+            line[item+1] = '0'
         if line[item] in sameParams:
             benchLine += ('--'+line[item]+' '+line[item+1]+' ')
         if line[item] == 'transA':

--- a/tuning/automation/ExtractSizes.py
+++ b/tuning/automation/ExtractSizes.py
@@ -728,7 +728,7 @@ def ConvertToRocBlasBenchCall(line):
     line = str(line.split(','))
     line = line.replace('"','').replace(' ','').replace('\'','').replace('[-{','').replace('}\\n]','').replace(':',',')
     line = line.split(',')
-    sameParams = set(['b_type','c_type','d_type','compute_type','lda','ldb','ldc','ldd','batch','batch_count','algo','solution_index','flags','stride_a','stride_b','stride_c','stride_d','alpha','beta'])
+    sameParams = set(['a_type','b_type','c_type','d_type','compute_type','lda','ldb','ldc','ldd','batch','batch_count','algo','solution_index','flags','stride_a','stride_b','stride_c','stride_d','alpha','beta'])
 
     for item in range(2,len(line)):
         if line[item] == 'flags' and line[item+1] == 'none':
@@ -747,14 +747,6 @@ def ConvertToRocBlasBenchCall(line):
             benchLine += ('-k '+line[item+1]+' ')
         if line[item] == 'call_count' or line[item] == "iters":
             benchLine += ('-i '+line[item+1])
-        if line[item] == 'a_type':
-            if line[item+1] == 'f32_r':
-                benchLine += ('-r s ')
-            elif line[item+1] == 'f16_r':
-                benchLine += ('-r h ')
-            else:
-                benchLine += ('-r d ')
-            benchLine += ('--'+line[item]+' '+line[item+1]+' ')
 
     return benchLine
 

--- a/tuning/scripts/provision_verification.sh
+++ b/tuning/scripts/provision_verification.sh
@@ -172,7 +172,7 @@ if [ -z "$(ls -A "${EXACT_PATH}")" ] || ${REDO}; then
     cp "${PATH_NAME}"/* "${EXACT_PATH}"
   done
 
-  cp "${REFERENCE_LIBRARY_ASM}"/* "${ASM_PATH}"
+  cp "${REFERENCE_LIBRARY_ASM}/${LIBRARY}"/* "${ASM_PATH}"
   cp "${REFERENCE_LIBRARY_ARCHIVE}"/* "${ARCHIVE_PATH}"
   cp "${ARCHIVE_PATH}"/*yaml "${ASM_PATH}"
 else

--- a/tuning/scripts/provision_verification.sh
+++ b/tuning/scripts/provision_verification.sh
@@ -125,6 +125,19 @@ if [ ${MERGE} == false ]; then
    MASSAGE=false
 fi
 
+if ! command -v awk &> /dev/null; then
+    echo "This script requires awk to be available in PATH"
+    exit 1
+fi
+if ! command -v python &> /dev/null; then
+    echo "This script requires python to be available in PATH"
+    exit 1
+fi
+if ! command -v xargs &> /dev/null; then
+    echo "This script requires xargs to be available in PATH"
+    exit 1
+fi
+
 # determine full path of tools root
 TOOLS_ROOT=$(realpath "${0}" | xargs dirname | xargs dirname)
 
@@ -249,12 +262,10 @@ else
   echo "rocBLAS already built: skipping"
 fi
 
-# TODO: way to set which Tensile to use for create library?
-# TODO: get correct Python version
-CREATE_LIBRARY_EXE=${ROCBLAS_PATH}/build/release/virtualenv/lib/python3.6/site-packages/Tensile/bin/TensileCreateLibrary
+PYTHON_MODULE_DIR=$(python --version | cut -c 8- | awk -F. '{printf("python%s.%s", $1,$2)}')
+CREATE_LIBRARY_EXE=${ROCBLAS_PATH}/build/release/virtualenv/lib/${PYTHON_MODULE_DIR}/site-packages/Tensile/bin/TensileCreateLibrary
 CREATE_LIBRARY_ARGS=(--merge-files --no-short-file-names \
-  --no-library-print-debug --cxx-compiler=hipcc \
-  --library-format=msgpack "${MERGE_PATH}" "${TENSILE_LIBRARY_PATH}" HIP)
+  --cxx-compiler=hipcc --library-format=msgpack "${MERGE_PATH}" "${TENSILE_LIBRARY_PATH}" HIP)
 
 # create new (tuned) Tensile library
 echo "Creating new Tensile library"

--- a/tuning/scripts/provision_verification.sh
+++ b/tuning/scripts/provision_verification.sh
@@ -193,6 +193,7 @@ if [ "${LIBRARY}" == arcturus ]; then
   fi
 fi
 
+export PYTHONPATH=${TENSILE_PATH}
 MERGE_SCRIPT=${TENSILE_PATH}/Tensile/Utilities/merge.py
 MASSAGE_SCRIPT=${REFERENCE_LIBRARY_ARCHIVE}/massage.py
 


### PR DESCRIPTION
672afc68985b149f1f19c90758c796cee1424537 fixes https://github.com/ROCm/Tensile/issues/2077 issue 1

8829b024de7db18a0773ac6e2542fb9ba308435b fixes https://github.com/ROCm/Tensile/issues/2077 Issue 4

39451b8faa4f1d055118e58817e7d76b80f646dc updates the tuning script to align with rocblas change 7972a13cb93611d12c47d72e3bf15acd8ca4b1ee

ff26d8ab116e0148c1db92ffac5dac2e104b047b partially fixes https://github.com/ROCm/Tensile/issues/2077 Issue 2, but many bugs with the rocblas log to tensile benchmark config conversion remains, not limited to:
1. Only the first data type configuration set in the rocblas log file is taken as the configuration for all the benchmark problems, however the log may contain different configurations 
    1. The different configurations should be forked instead of being only in the common benchmark config paramters, but they are not
2. Configurations where the input and output dtypes are not the same are borken

59226983dff72d875edbb3000a564d96f18567cf updates the parameters of TensileCreateLibrary to work with the current version and fixes the TODO in provision_verification that previously hardcoded python 3.6, which is ofc not useful in 2025

Overall the tuning scripts are still in an __extremely sorry__ state, there are many pitfalls in these scripts such as:
1. various Chips are hard coded in various places, but it only goes up to Arcturus, leaving Aldebaran and up in the cold, never mind gfx10+
2. Very little error handling while with many faulty assumptions about system environment
3. various flags like --redo do not work due to faulty assumptions about the behavior of a posix shell
4. many many more