### PR TITLE
Fix gfx908 builds

### DIFF
--- a/Tensile/BuildCommands/SourceCommands.py
+++ b/Tensile/BuildCommands/SourceCommands.py
@@ -191,7 +191,7 @@ def _buildSourceCodeObjectFile(
         )
 
     for target in _listTargetTriples(bundler, objPath):
-        match = re.search("gfx.*$", target):
+        match = re.search("gfx.*$", target)
         if match:
             arch = re.sub(":", "-", match.group())
             coPathRaw = _computeSourceCodeObjectPath(target, kernelPath.stem, buildPath, arch)

--- a/Tensile/BuildCommands/SourceCommands.py
+++ b/Tensile/BuildCommands/SourceCommands.py
@@ -191,7 +191,8 @@ def _buildSourceCodeObjectFile(
         )
 
     for target in _listTargetTriples(bundler, objPath):
-        if match := re.search("gfx.*$", target):
+        match = re.search("gfx.*$", target):
+        if match:
             arch = re.sub(":", "-", match.group())
             coPathRaw = _computeSourceCodeObjectPath(target, kernelPath.stem, buildPath, arch)
             if not coPathRaw:

--- a/Tensile/BuildCommands/SourceCommands.py
+++ b/Tensile/BuildCommands/SourceCommands.py
@@ -71,7 +71,7 @@ def _compileSourceObjectFile(
     hipFlags = ["-D__HIP_HCC_COMPAT_MODE__=1"]
     # TODO(@tensile-infra): hipcc is deprecated and should be removed for ROCm 6.5
     hipFlags += (
-        ["--genco"] if cxxCompiler == "hipcc" else ["--cuda-device-only", "-x", "hip", "-O3"]
+        ["--genco"] if os.path.basename(cxxCompiler) == "hipcc" else ["--cuda-device-only", "-x", "hip", "-O3"]
     )
     hipFlags += ["-I", outputPath]
 

--- a/Tensile/BuildCommands/SourceCommands.py
+++ b/Tensile/BuildCommands/SourceCommands.py
@@ -71,7 +71,9 @@ def _compileSourceObjectFile(
     hipFlags = ["-D__HIP_HCC_COMPAT_MODE__=1"]
     # TODO(@tensile-infra): hipcc is deprecated and should be removed for ROCm 6.5
     hipFlags += (
-        ["--genco"] if os.path.basename(cxxCompiler) == "hipcc" else ["--cuda-device-only", "-x", "hip", "-O3"]
+        ["--genco"]
+        if os.path.basename(cxxCompiler) == "hipcc"
+        else ["--cuda-device-only", "-x", "hip", "-O3"]
     )
     hipFlags += ["-I", outputPath]
 

--- a/Tensile/KernelWriterSource.py
+++ b/Tensile/KernelWriterSource.py
@@ -379,50 +379,32 @@ class KernelWriterSource(KernelWriter):
       kStr += "  } while (assumed != old);%s" % (self.endLine)
       kStr += "}%s" % (self.endLine)
       """
-      if os.path.basename(globalParameters["CxxCompiler"]) == "hipcc" or os.path.basename(globalParameters["CxxCompiler"]) == "amdclang++":
-        kStr += self.endLine
-        kStr += "__device__ inline int atomicAddType(int *fPtr, int operand)%s" % (self.endLine)
-        kStr += "{%s" % (self.endLine)
-        kStr += "  return atomicAdd(fPtr,operand);%s" % (self.endLine)
-        kStr += "}%s" % (self.endLine)
-        kStr += self.endLine
-        kStr += "__device__ inline unsigned int atomicAddType(unsigned int *fPtr, unsigned int operand)%s" % (self.endLine)
-        kStr += "{%s" % (self.endLine)
-        kStr += "  return atomicAdd(fPtr,operand);%s" % (self.endLine)
-        kStr += "}%s" % (self.endLine)
-        kStr += self.endLine
-        kStr += "__device__ inline unsigned long long int atomicAddType(unsigned long long int *fPtr, unsigned long long int operand)%s" % (self.endLine)
-        kStr += "{%s" % (self.endLine)
-        kStr += "  return atomicAdd(fPtr,operand);%s" % (self.endLine)
-        kStr += "}%s" % (self.endLine)
-        kStr += self.endLine
-        kStr += "__device__ inline float atomicAddType(float *fPtr, float operand)%s" % (self.endLine)
-        kStr += "{%s" % (self.endLine)
-        kStr += "  return atomicAdd(fPtr,operand);%s" % (self.endLine)
-        kStr += "}%s" % (self.endLine)
-        kStr += self.endLine
-        kStr += "__device__ inline double atomicAddType(double *fPtr, double operand)%s" % (self.endLine)
-        kStr += "{%s" % (self.endLine)
-        kStr += "  return atomicAdd(fPtr,operand);%s" % (self.endLine)
-        kStr += "}%s" % (self.endLine)
-        kStr += self.endLine
-      else:
-        printWarning("Unsupported C++ compiler for atomicAddType: {}".format(globalParameters["CxxCompiler"]))
-        kStr += self.endLine
-        kStr += "template <typename T>%s" % (self.endLine)
-        kStr += "__device__ inline void atomicAddType(%s%sT *fPtr, T operand) {%s" \
-            % (self.volatileStr, self.globalPtrStr, self.endLine)
-        kStr += "  std::atomic<T> *aPtr = reinterpret_cast<std::atomic<T>*>(fPtr);%s" % (self.endLine)
-        kStr += "  T oldValue, newValue;%s" % (self.endLine)
-        kStr += "  oldValue = aPtr->load(std::memory_order_relaxed);%s" % (self.endLine)
-        kStr += "  do {%s" % (self.endLine)
-        kStr += "    newValue = oldValue + operand;%s" % (self.endLine)
-        #kStr += "    prevReturn = %s(uPtr, prevVal.ui, newVal.ui);%s" \
-        #    % (self.atomicCasStr, self.endLine)
-        #kStr += "  } while ( !std::atomic_compare_exchange_weak_explicit(aPtr, &oldValue, newValue, std::memory_order_acq_rel, std::memory_order_release) );%s" % (self.endLine)
-        kStr += "  } while ( !std::atomic_compare_exchange_weak_explicit(aPtr, &oldValue, newValue, std::memory_order_relaxed, std::memory_order_release) );%s" % (self.endLine)
-        kStr += "}%s" % (self.endLine)
-
+      kStr += self.endLine
+      kStr += "__device__ inline int atomicAddType(int *fPtr, int operand)%s" % (self.endLine)
+      kStr += "{%s" % (self.endLine)
+      kStr += "  return atomicAdd(fPtr,operand);%s" % (self.endLine)
+      kStr += "}%s" % (self.endLine)
+      kStr += self.endLine
+      kStr += "__device__ inline unsigned int atomicAddType(unsigned int *fPtr, unsigned int operand)%s" % (self.endLine)
+      kStr += "{%s" % (self.endLine)
+      kStr += "  return atomicAdd(fPtr,operand);%s" % (self.endLine)
+      kStr += "}%s" % (self.endLine)
+      kStr += self.endLine
+      kStr += "__device__ inline unsigned long long int atomicAddType(unsigned long long int *fPtr, unsigned long long int operand)%s" % (self.endLine)
+      kStr += "{%s" % (self.endLine)
+      kStr += "  return atomicAdd(fPtr,operand);%s" % (self.endLine)
+      kStr += "}%s" % (self.endLine)
+      kStr += self.endLine
+      kStr += "__device__ inline float atomicAddType(float *fPtr, float operand)%s" % (self.endLine)
+      kStr += "{%s" % (self.endLine)
+      kStr += "  return atomicAdd(fPtr,operand);%s" % (self.endLine)
+      kStr += "}%s" % (self.endLine)
+      kStr += self.endLine
+      kStr += "__device__ inline double atomicAddType(double *fPtr, double operand)%s" % (self.endLine)
+      kStr += "{%s" % (self.endLine)
+      kStr += "  return atomicAdd(fPtr,operand);%s" % (self.endLine)
+      kStr += "}%s" % (self.endLine)
+      kStr += self.endLine
       kStr += "#endif%s" % self.endLine
 
     kStr += "#define MAGIC_DIV1(dividend, magicNumber, magicShift) ((uint64_t)(dividend) * magicNumber >> magicShift)%s" % self.endLine

--- a/Tensile/KernelWriterSource.py
+++ b/Tensile/KernelWriterSource.py
@@ -22,10 +22,12 @@
 #
 ################################################################################
 
+import os
+
 from . import Code
 from .DataType import DataType
 from .SolutionStructs import isPackedIndex
-from .Common import globalParameters, printExit, roundUp
+from .Common import globalParameters, printExit, printWarning, roundUp
 from .KernelWriter import KernelWriter
 
 ################################################################################
@@ -377,7 +379,7 @@ class KernelWriterSource(KernelWriter):
       kStr += "  } while (assumed != old);%s" % (self.endLine)
       kStr += "}%s" % (self.endLine)
       """
-      if globalParameters["CxxCompiler"] == "hipcc" or globalParameters["CxxCompiler"] == "amdclang++":
+      if os.path.basename(globalParameters["CxxCompiler"]) == "hipcc" or os.path.basename(globalParameters["CxxCompiler"]) == "amdclang++":
         kStr += self.endLine
         kStr += "__device__ inline int atomicAddType(int *fPtr, int operand)%s" % (self.endLine)
         kStr += "{%s" % (self.endLine)
@@ -405,6 +407,7 @@ class KernelWriterSource(KernelWriter):
         kStr += "}%s" % (self.endLine)
         kStr += self.endLine
       else:
+        printWarning("Unsupported C++ compiler for atomicAddType: {}".format(globalParameters["CxxCompiler"]))
         kStr += self.endLine
         kStr += "template <typename T>%s" % (self.endLine)
         kStr += "__device__ inline void atomicAddType(%s%sT *fPtr, T operand) {%s" \

--- a/Tensile/KernelWriterSource.py
+++ b/Tensile/KernelWriterSource.py
@@ -22,12 +22,10 @@
 #
 ################################################################################
 
-import os
-
 from . import Code
 from .DataType import DataType
 from .SolutionStructs import isPackedIndex
-from .Common import globalParameters, printExit, printWarning, roundUp
+from .Common import globalParameters, printExit, roundUp
 from .KernelWriter import KernelWriter
 
 ################################################################################


### PR DESCRIPTION
**Summary:**

rocBLAS SLES builds that target gfx908 are broken because Tensile now uses a full compiler path. This PR fixes this issue by removing an if/else block that is unnecessary and eliminates an erroneous test. Also fixes an error relating to unsupported assignment expression operators in python 3.6, which is still supported in SLES images.
