### PR TITLE
Change clang-offload-bundler to 4-tuple

### DIFF
--- a/Tensile/BuildCommands/SharedCommands.py
+++ b/Tensile/BuildCommands/SharedCommands.py
@@ -25,7 +25,7 @@ def compressCodeObject(
         "--compress",
         "--type=o",
         "--bundle-align=4096",
-        f"--targets=host-x86_64-unknown-linux,hipv4-amdgcn-amd-amdhsa--{gfx}",
+        f"--targets=host-x86_64-unknown-linux-gnu,hipv4-amdgcn-amd-amdhsa--{gfx}",
         f"--input={os.devnull}",
         f"--input={str(coPathSrc)}",
         f"--output={str(coPathDest)}",


### PR DESCRIPTION
resolves #2086 

**Summary:**
Change usage of clang-offload-bundler from 3-tuple to 4-tuple with the new <env> parameter. This was the only usage I could find in the repo.
