### PR TITLE
Only warn when caps mismatch

### DIFF
--- a/Tensile/Common.py
+++ b/Tensile/Common.py
@@ -2133,7 +2133,7 @@ def GetAsmCaps(isaVersion: IsaVersion, hipVersion: SemanticVersion, cachedAsmCap
       elif derivedAsmCaps != cachedAsmCaps[isaVersion]:
         exitFlag = True
       if exitFlag:
-        printExit("Cached asm caps differ from derived asm caps for {}".format(isaVersion))
+        printWarning("Cached asm caps differ from derived asm caps for {}".format(isaVersion))
     return derivedAsmCaps
   else:
     printWarning("Assembler not present, asm caps loaded from cache are unverified")


### PR DESCRIPTION
There are different environments used in testing and each of the environments are reporting different capabilities. This has introduced a dependency cycle that we cannot get out of without temporarily making this change.
