### PR TITLE
Revert CHANGELOG update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,45 +5,45 @@
 ### Added
 
 - Nightly builds with performance statistics
-- ASM cache capabilities for reuse
-- Virtual environment (venv) for `TensileCreateLibrary` invocation on Linux
-- Flag to keep `build_tmp` when running Tensile
+- Cache asm capabilities for reuse
+- venv for Tensile create on Linux
+- Flag to keep build_tmp when running Tensile
 - Generalized profiling scripts
-- Support for gfx1151
-- Single-threaded support in `TensileCreateLibrary`
+- GFX1151 support
+- Single-threaded support in TensileCreateLibrary
 - Logic to remove temporary build artifacts
 
 ### Changed
 
 - Updated Tensile documents (API reference, README.md, and comments)
-- Disabled ASM cache for tests
-- Replaced Perl script with `hipcc.bat` as a compiler on Windows
-- Improved CHANGELOG.md
+- Disabled asm-cache for tests
+- Used hipcc.bat as a compiler on Windows instead of the Perl script
+- Improved clarity of CHANGELOG.md
 - Enabled external CI
 - Improved Tensile documentation
 - Refactored kernel source and header creation
-- Refactored `writeKernels` in `TensileCreateLibrary`
-- Suppressed developer warnings to simplify the Tensile output
-- Introduced an explicit cast when invoking `min`
-- Introduced cache abbreviations to compute kernel names
+- Refactored writeKernels in TensileCreateLibrary
+- Suppressed developer warnings (simplifying the Tensile output)
+- Used an explicit cast when invoking min is called
+- Used cache abbreviations to compute kernel names
 
 ### Removed
 
 - OCL backend
 - Unsupported tests
-- Deep copy in `TensileCreateLibrary`
+- Deep copy in TensileCreateLibrary
 
 ### Optimized
 
-- Linearized ASM register search to reduce build time
+- Linearized asm register search to reduce build time
 
 ### Resolved issues
 
 - Fixed Stream-K dynamic grid model
-- Fixed logic related to caching ASM capabilities
-- Fixed `accvgpr` overflow
-- Fixed test failures in SLES containers when running `TensileTests`
-- Fixed a regression that prevents `TensileCreateLibrary` from completing when fallback logic is not available
+- Fixed logic related to caching asm capabilities
+- Fixed accvgpr overflow
+- Fixed test failures in SLES containers when running TensileTests
+- Fixed a regression that prevents TensileCreateLibrary from completing when fallback logic is not available
 
 ## Tensile 4.42.0 for ROCm 6.3.0
 


### PR DESCRIPTION
We want the changelog to remain consistent with the 6.4 release, so we are reverting the most recent changes because we are close to the general release date, they aren't a significant value, and would potentially risk commit mismatch between Tensile and rocBLAS.
